### PR TITLE
Some improvements and fixes

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -820,7 +820,7 @@ namespace UndertaleModLib.Models
 
                 public bool Visible { get; set; }
                 public bool Foreground { get; set; }
-                public UndertaleSprite Sprite { get => _Sprite.Resource; set { _Sprite.Resource = value; OnPropertyChanged(); ParentLayer.ParentRoom.UpdateBGColorLayer(); } }
+                public UndertaleSprite Sprite { get => _Sprite.Resource; set { _Sprite.Resource = value; OnPropertyChanged(); ParentLayer?.ParentRoom?.UpdateBGColorLayer(); } }
                 public bool TiledHorizontally { get => _TiledHorizontally; set { _TiledHorizontally = value; OnPropertyChanged(); } }
                 public bool TiledVertically { get => _TiledVertically; set { _TiledVertically = value; OnPropertyChanged(); } }
                 public bool Stretch { get => _Stretch; set { _Stretch = value; OnPropertyChanged(); } }

--- a/UndertaleModTool/Repackers/ImportGameObject.csx
+++ b/UndertaleModTool/Repackers/ImportGameObject.csx
@@ -17,269 +17,269 @@ ReadGameObject(gameObjectInputPath);
 
 void ReadGameObject(string filePath)
 {
-	FileStream stream = File.OpenRead(filePath);
-	byte[] jsonUtf8Bytes = new byte[stream.Length];
+    FileStream stream = File.OpenRead(filePath);
+    byte[] jsonUtf8Bytes = new byte[stream.Length];
 
-	stream.Read(jsonUtf8Bytes, 0, jsonUtf8Bytes.Length);
-	stream.Close();
+    stream.Read(jsonUtf8Bytes, 0, jsonUtf8Bytes.Length);
+    stream.Close();
 
-	JsonReaderOptions options = new JsonReaderOptions
-	{
-		AllowTrailingCommas = true,
-		CommentHandling = JsonCommentHandling.Skip
-	};
+    JsonReaderOptions options = new JsonReaderOptions
+    {
+        AllowTrailingCommas = true,
+        CommentHandling = JsonCommentHandling.Skip
+    };
 
-	Utf8JsonReader reader = new Utf8JsonReader(jsonUtf8Bytes, options);
+    Utf8JsonReader reader = new Utf8JsonReader(jsonUtf8Bytes, options);
 
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartObject);
-	ReadName(ref reader);
-	ReadMainValues(ref reader);
-	ReadPhysicsVerts(ref reader);
-	ReadAllEvents(ref reader);
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
-	if (Data.GameObjects.ByName(newGameObject.Name.Content) == null) Data.GameObjects.Add(newGameObject);
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartObject);
+    ReadName(ref reader);
+    ReadMainValues(ref reader);
+    ReadPhysicsVerts(ref reader);
+    ReadAllEvents(ref reader);
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+    if (Data.GameObjects.ByName(newGameObject.Name.Content) == null) Data.GameObjects.Add(newGameObject);
 }
 
 void ReadMainValues(ref Utf8JsonReader reader)
 {
-	string spriteName = ReadString(ref reader);
+    string spriteName = ReadString(ref reader);
 
-	newGameObject.Visible = ReadBool(ref reader);
-	newGameObject.Solid = ReadBool(ref reader);
-	newGameObject.Depth = (int) ReadNum(ref reader);
-	newGameObject.Persistent = ReadBool(ref reader);
+    newGameObject.Visible = ReadBool(ref reader);
+    newGameObject.Solid = ReadBool(ref reader);
+    newGameObject.Depth = (int) ReadNum(ref reader);
+    newGameObject.Persistent = ReadBool(ref reader);
 
-	string parentName = ReadString(ref reader);
-	string texMaskName = ReadString(ref reader);
+    string parentName = ReadString(ref reader);
+    string texMaskName = ReadString(ref reader);
 
-	newGameObject.UsesPhysics = ReadBool(ref reader);
-	newGameObject.IsSensor = ReadBool(ref reader);
-	newGameObject.CollisionShape = (CollisionShapeFlags) ReadNum(ref reader);
-	newGameObject.Density = ReadFloat(ref reader);
-	newGameObject.Restitution = ReadFloat(ref reader);
-	newGameObject.Group = (uint) ReadNum(ref reader);
-	newGameObject.LinearDamping = ReadFloat(ref reader);
-	newGameObject.AngularDamping = ReadFloat(ref reader);
-	newGameObject.Friction = ReadFloat(ref reader);
-	newGameObject.Awake = ReadBool(ref reader);
-	newGameObject.Kinematic = ReadBool(ref reader);
+    newGameObject.UsesPhysics = ReadBool(ref reader);
+    newGameObject.IsSensor = ReadBool(ref reader);
+    newGameObject.CollisionShape = (CollisionShapeFlags) ReadNum(ref reader);
+    newGameObject.Density = ReadFloat(ref reader);
+    newGameObject.Restitution = ReadFloat(ref reader);
+    newGameObject.Group = (uint) ReadNum(ref reader);
+    newGameObject.LinearDamping = ReadFloat(ref reader);
+    newGameObject.AngularDamping = ReadFloat(ref reader);
+    newGameObject.Friction = ReadFloat(ref reader);
+    newGameObject.Awake = ReadBool(ref reader);
+    newGameObject.Kinematic = ReadBool(ref reader);
 
-	newGameObject.Sprite = (spriteName == null) ? null : Data.Sprites.ByName(spriteName);
+    newGameObject.Sprite = (spriteName == null) ? null : Data.Sprites.ByName(spriteName);
 
-	newGameObject.ParentId = (parentName == null) ? null : Data.GameObjects.ByName(parentName);
+    newGameObject.ParentId = (parentName == null) ? null : Data.GameObjects.ByName(parentName);
 
-	newGameObject.TextureMaskId = (texMaskName == null) ? null : Data.Sprites.ByName(texMaskName);
+    newGameObject.TextureMaskId = (texMaskName == null) ? null : Data.Sprites.ByName(texMaskName);
 }
 
 void ReadPhysicsVerts(ref Utf8JsonReader reader)
 {
-	newGameObject.PhysicsVertices.Clear();
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.StartObject)
-		{
-			UndertaleGameObject.UndertalePhysicsVertex physVert = new UndertaleGameObject.UndertalePhysicsVertex();
-			physVert.X = ReadNum(ref reader);
-			physVert.Y = ReadNum(ref reader);
-			newGameObject.PhysicsVertices.Add(physVert);
-			continue;
-		}
+    newGameObject.PhysicsVertices.Clear();
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            UndertaleGameObject.UndertalePhysicsVertex physVert = new UndertaleGameObject.UndertalePhysicsVertex();
+            physVert.X = ReadNum(ref reader);
+            physVert.Y = ReadNum(ref reader);
+            newGameObject.PhysicsVertices.Add(physVert);
+            continue;
+        }
 
-		if (reader.TokenType == JsonTokenType.EndObject) continue;
-		if (reader.TokenType == JsonTokenType.EndArray) break;
+        if (reader.TokenType == JsonTokenType.EndObject) continue;
+        if (reader.TokenType == JsonTokenType.EndArray) break;
 
-		throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
-	}
+        throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
+    }
 }
 
 void ReadAllEvents(ref Utf8JsonReader reader)
 {
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
-	int eventListIndex = -1;
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.StartArray)
-		{
-			eventListIndex++;
-			newGameObject.Events[eventListIndex].Clear();
-			foreach (UndertaleGameObject.Event eventToAdd in ReadEvents(ref reader)) newGameObject.Events[eventListIndex].Add(eventToAdd);
-			continue;
-		}
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
+    int eventListIndex = -1;
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.StartArray)
+        {
+            eventListIndex++;
+            newGameObject.Events[eventListIndex].Clear();
+            foreach (UndertaleGameObject.Event eventToAdd in ReadEvents(ref reader)) newGameObject.Events[eventListIndex].Add(eventToAdd);
+            continue;
+        }
 
-		if (reader.TokenType == JsonTokenType.EndObject) continue;
-		if (reader.TokenType == JsonTokenType.EndArray) break;
+        if (reader.TokenType == JsonTokenType.EndObject) continue;
+        if (reader.TokenType == JsonTokenType.EndArray) break;
 
-		throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
-	}
+        throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
+    }
 }
 
 List<UndertaleGameObject.Event> ReadEvents(ref Utf8JsonReader reader)
 {
-	List<UndertaleGameObject.Event> eventsToReturn = new List<UndertaleGameObject.Event>();
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.PropertyName) continue;
-		if (reader.TokenType == JsonTokenType.EndArray) return eventsToReturn;
-		if (reader.TokenType != JsonTokenType.StartObject) continue;
+    List<UndertaleGameObject.Event> eventsToReturn = new List<UndertaleGameObject.Event>();
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.PropertyName) continue;
+        if (reader.TokenType == JsonTokenType.EndArray) return eventsToReturn;
+        if (reader.TokenType != JsonTokenType.StartObject) continue;
 
-		UndertaleGameObject.Event newEvent = new UndertaleGameObject.Event();
-		newEvent.EventSubtype = (uint) ReadNum(ref reader);
-		newEvent.Actions.Clear();
-		foreach (UndertaleGameObject.EventAction action in ReadActions(ref reader)) newEvent.Actions.Add(action);
-		eventsToReturn.Add(newEvent);
-		ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
-	}
+        UndertaleGameObject.Event newEvent = new UndertaleGameObject.Event();
+        newEvent.EventSubtype = (uint) ReadNum(ref reader);
+        newEvent.Actions.Clear();
+        foreach (UndertaleGameObject.EventAction action in ReadActions(ref reader)) newEvent.Actions.Add(action);
+        eventsToReturn.Add(newEvent);
+        ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+    }
 
-	throw new Exception("ERROR: Could not find end of array token - Events.");
+    throw new Exception("ERROR: Could not find end of array token - Events.");
 }
 
 List<UndertaleGameObject.EventAction> ReadActions(ref Utf8JsonReader reader)
 {
-	List<UndertaleGameObject.EventAction> actionsToReturn = new List<UndertaleGameObject.EventAction>();
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.PropertyName) continue;
-		if (reader.TokenType == JsonTokenType.EndArray) return actionsToReturn;
-		if (reader.TokenType != JsonTokenType.StartObject) continue;
+    List<UndertaleGameObject.EventAction> actionsToReturn = new List<UndertaleGameObject.EventAction>();
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.PropertyName) continue;
+        if (reader.TokenType == JsonTokenType.EndArray) return actionsToReturn;
+        if (reader.TokenType != JsonTokenType.StartObject) continue;
 
-		UndertaleGameObject.EventAction newAction = ReadAction(ref reader);
-		actionsToReturn.Add(newAction);
-	}
+        UndertaleGameObject.EventAction newAction = ReadAction(ref reader);
+        actionsToReturn.Add(newAction);
+    }
 
-	throw new Exception("ERROR: Could not find end of array token - Actions.");
+    throw new Exception("ERROR: Could not find end of array token - Actions.");
 }
 
 UndertaleGameObject.EventAction ReadAction(ref Utf8JsonReader reader)
 {
-	UndertaleGameObject.EventAction newAction = new UndertaleGameObject.EventAction();
-	newAction.LibID = (uint) ReadNum(ref reader);
-	newAction.ID = (uint) ReadNum(ref reader);
-	newAction.Kind = (uint) ReadNum(ref reader);
-	newAction.UseRelative = ReadBool(ref reader);
-	newAction.IsQuestion = ReadBool(ref reader);
-	newAction.UseApplyTo = ReadBool(ref reader);
-	newAction.ExeType = (uint) ReadNum(ref reader);
-	string actionName = ReadString(ref reader);
-	string codeId = ReadString(ref reader);
-	newAction.ArgumentCount = (uint) ReadNum(ref reader);
-	newAction.Who = (int) ReadNum(ref reader);
-	newAction.Relative = ReadBool(ref reader);
-	newAction.IsNot = ReadBool(ref reader);
+    UndertaleGameObject.EventAction newAction = new UndertaleGameObject.EventAction();
+    newAction.LibID = (uint) ReadNum(ref reader);
+    newAction.ID = (uint) ReadNum(ref reader);
+    newAction.Kind = (uint) ReadNum(ref reader);
+    newAction.UseRelative = ReadBool(ref reader);
+    newAction.IsQuestion = ReadBool(ref reader);
+    newAction.UseApplyTo = ReadBool(ref reader);
+    newAction.ExeType = (uint) ReadNum(ref reader);
+    string actionName = ReadString(ref reader);
+    string codeId = ReadString(ref reader);
+    newAction.ArgumentCount = (uint) ReadNum(ref reader);
+    newAction.Who = (int) ReadNum(ref reader);
+    newAction.Relative = ReadBool(ref reader);
+    newAction.IsNot = ReadBool(ref reader);
 
-	if (actionName == null)
-	{
-		newAction.ActionName = null;
-	}
-	else
-	{
-		newAction.ActionName = new UndertaleString(actionName);
+    if (actionName == null)
+    {
+        newAction.ActionName = null;
+    }
+    else
+    {
+        newAction.ActionName = new UndertaleString(actionName);
 
-		if (!Data.Strings.Any(s => s == newAction.ActionName))
-			Data.Strings.Add(newAction.ActionName);
-	}
+        if (!Data.Strings.Any(s => s == newAction.ActionName))
+            Data.Strings.Add(newAction.ActionName);
+    }
 
-	if (codeId == null)
-		newAction.CodeId = null;
-	else
-		newAction.CodeId = Data.Code.ByName(codeId);
+    if (codeId == null)
+        newAction.CodeId = null;
+    else
+        newAction.CodeId = Data.Code.ByName(codeId);
 
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
-	return newAction;
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+    return newAction;
 }
 
 void ReadName(ref Utf8JsonReader reader)
 {
-	string name = ReadString(ref reader);
-	if (name == null) throw new Exception("ERROR: Object name was null - object name must be defined!");
-	if (Data.GameObjects.ByName(name) != null)
-	{
-		newGameObject = Data.GameObjects.ByName(name);
-	}
-	else
-	{
-		newGameObject = new UndertaleGameObject();
-		newGameObject.Name = new UndertaleString(name);
-		Data.Strings.Add(newGameObject.Name);
-	}
+    string name = ReadString(ref reader);
+    if (name == null) throw new Exception("ERROR: Object name was null - object name must be defined!");
+    if (Data.GameObjects.ByName(name) != null)
+    {
+        newGameObject = Data.GameObjects.ByName(name);
+    }
+    else
+    {
+        newGameObject = new UndertaleGameObject();
+        newGameObject.Name = new UndertaleString(name);
+        Data.Strings.Add(newGameObject.Name);
+    }
 }
 
 // Read tokens of specified type
 
 bool ReadBool(ref Utf8JsonReader reader)
 {
-	while (reader.Read())
-	{
-		switch (reader.TokenType)
-		{
-			case JsonTokenType.PropertyName: continue;
-			case JsonTokenType.True: return true;
-			case JsonTokenType.False: return false;
-			default: throw new Exception($"ERROR: Unexpected token type. Expected Boolean - found {reader.TokenType}");
-		}
-	}
+    while (reader.Read())
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.PropertyName: continue;
+            case JsonTokenType.True: return true;
+            case JsonTokenType.False: return false;
+            default: throw new Exception($"ERROR: Unexpected token type. Expected Boolean - found {reader.TokenType}");
+        }
+    }
 
-	throw new Exception("ERROR: Did not find value of expected type. Expected Boolean.");
+    throw new Exception("ERROR: Did not find value of expected type. Expected Boolean.");
 }
 
 long ReadNum(ref Utf8JsonReader reader)
 {
-	while (reader.Read())
-	{
-		switch (reader.TokenType)
-		{
-			case JsonTokenType.PropertyName: continue;
-			case JsonTokenType.Number: return reader.GetInt64();
-			default: throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
-		}
-	}
+    while (reader.Read())
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.PropertyName: continue;
+            case JsonTokenType.Number: return reader.GetInt64();
+            default: throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
+        }
+    }
 
-	throw new Exception("ERROR: Did not find value of expected type. Expected Integer.");
+    throw new Exception("ERROR: Did not find value of expected type. Expected Integer.");
 }
 
 float ReadFloat(ref Utf8JsonReader reader)
 {
-	while (reader.Read())
-	{
-		switch (reader.TokenType)
-		{
-			case JsonTokenType.PropertyName: continue;
-			case JsonTokenType.Number: return reader.GetSingle();
-			default: throw new Exception($"ERROR: Unexpected token type. Expected Decimal - found {reader.TokenType}");
-		}
-	}
+    while (reader.Read())
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.PropertyName: continue;
+            case JsonTokenType.Number: return reader.GetSingle();
+            default: throw new Exception($"ERROR: Unexpected token type. Expected Decimal - found {reader.TokenType}");
+        }
+    }
 
-	throw new Exception("ERROR: Did not find value of expected type. Expected Decimal.");
+    throw new Exception("ERROR: Did not find value of expected type. Expected Decimal.");
 }
 
 string ReadString(ref Utf8JsonReader reader)
 {
-	while (reader.Read())
-	{
-		switch (reader.TokenType)
-		{
-			case JsonTokenType.PropertyName: continue;
-			case JsonTokenType.String: return reader.GetString();
-			case JsonTokenType.Null: return null;
-			default: throw new Exception($"ERROR: Unexpected token type. Expected String - found {reader.TokenType}");
-		}
-	}
+    while (reader.Read())
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.PropertyName: continue;
+            case JsonTokenType.String: return reader.GetString();
+            case JsonTokenType.Null: return null;
+            default: throw new Exception($"ERROR: Unexpected token type. Expected String - found {reader.TokenType}");
+        }
+    }
 
-	throw new Exception("ERROR: Did not find value of expected type. Expected String.");
+    throw new Exception("ERROR: Did not find value of expected type. Expected String.");
 }
 
 // Watch for certain meta-tokens
 
 void ReadAnticipateJSONObject(ref Utf8JsonReader reader, JsonTokenType allowedTokenType)
 {
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.PropertyName)
-			continue;
-		if (reader.TokenType == allowedTokenType)
-			return;
-		throw new Exception($"ERROR: Unexpected token type. Expected {allowedTokenType} - found {reader.TokenType}");
-	}
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.PropertyName)
+            continue;
+        if (reader.TokenType == allowedTokenType)
+            return;
+        throw new Exception($"ERROR: Unexpected token type. Expected {allowedTokenType} - found {reader.TokenType}");
+    }
 
-	throw new Exception("ERROR: Did not find value of expected type. Expected String.");
+    throw new Exception("ERROR: Did not find value of expected type. Expected String.");
 }

--- a/UndertaleModTool/Repackers/ImportGameObject.csx
+++ b/UndertaleModTool/Repackers/ImportGameObject.csx
@@ -7,6 +7,8 @@ using System.Text.Json;
 using System.Linq;
 using UndertaleModLib.Models;
 
+EnsureDataLoaded();
+
 ScriptMessage("Select the GameObject to import");
 string gameObjectInputPath = PromptLoadFile("Import which file", "Json Files|*.json");
 if (gameObjectInputPath == null) throw new ScriptException("The game object's path was not set.");

--- a/UndertaleModTool/Repackers/ImportRoom.csx
+++ b/UndertaleModTool/Repackers/ImportRoom.csx
@@ -21,707 +21,713 @@ ReadRoom(roomInputPath);
 
 void ReadRoom(string filePath)
 {
-	FileStream stream = File.OpenRead(filePath);
-	byte[] jsonUtf8Bytes = new byte[stream.Length];
+    FileStream stream = File.OpenRead(filePath);
+    byte[] jsonUtf8Bytes = new byte[stream.Length];
 
-	stream.Read(jsonUtf8Bytes, 0, jsonUtf8Bytes.Length);
-	stream.Close();
+    stream.Read(jsonUtf8Bytes, 0, jsonUtf8Bytes.Length);
+    stream.Close();
 
-	JsonReaderOptions options = new JsonReaderOptions
-	{
-		AllowTrailingCommas = true,
-		CommentHandling = JsonCommentHandling.Skip
-	};
+    JsonReaderOptions options = new JsonReaderOptions
+    {
+        AllowTrailingCommas = true,
+        CommentHandling = JsonCommentHandling.Skip
+    };
 
-	Utf8JsonReader reader = new Utf8JsonReader(jsonUtf8Bytes, options);
+    Utf8JsonReader reader = new Utf8JsonReader(jsonUtf8Bytes, options);
 
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartObject);
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartObject);
 
-	ReadName(ref reader);
-	ReadMainValues(ref reader);
+    ReadName(ref reader);
+    ReadMainValues(ref reader);
 
-	ClearRoomLists();
+    ClearRoomLists();
 
-	ReadBackgrounds(ref reader);
-	ReadViews(ref reader);
-	ReadGameObjects(ref reader);
-	ReadTiles(ref reader);
-	ReadLayers(ref reader);
+    ReadBackgrounds(ref reader);
+    ReadViews(ref reader);
+    ReadGameObjects(ref reader);
+    ReadTiles(ref reader);
+    ReadLayers(ref reader);
 
-	// Adds room to data file, if it doesn't exist.
-	if (Data.Rooms.ByName(newRoom.Name.Content) == null)
-		Data.Rooms.Add(newRoom);
+    // Adds room to data file, if it doesn't exist.
+    if (Data.Rooms.ByName(newRoom.Name.Content) == null)
+        Data.Rooms.Add(newRoom);
 
 }
 
 void ReadMainValues(ref Utf8JsonReader reader)
 {
-	string caption = ReadString(ref reader);
+    string caption = ReadString(ref reader);
 
-	newRoom.Width = (uint) ReadNum(ref reader);
-	newRoom.Height = (uint) ReadNum(ref reader);
-	newRoom.Speed = (uint) ReadNum(ref reader);
-	newRoom.Persistent = ReadBool(ref reader);
-	newRoom.BackgroundColor = (uint) ReadNum(ref reader);
-	newRoom.DrawBackgroundColor = ReadBool(ref reader);
+    newRoom.Width = (uint) ReadNum(ref reader);
+    newRoom.Height = (uint) ReadNum(ref reader);
+    newRoom.Speed = (uint) ReadNum(ref reader);
+    newRoom.Persistent = ReadBool(ref reader);
+    newRoom.BackgroundColor = (uint) ReadNum(ref reader);
+    newRoom.DrawBackgroundColor = ReadBool(ref reader);
 
-	string ccIdName = ReadString(ref reader);
+    string ccIdName = ReadString(ref reader);
 
-	newRoom.Flags = (UndertaleRoom.RoomEntryFlags) ReadNum(ref reader);
-	newRoom.World = ReadBool(ref reader);
-	newRoom.Top = (uint) ReadNum(ref reader);
-	newRoom.Left = (uint) ReadNum(ref reader);
-	newRoom.Right = (uint) ReadNum(ref reader);
-	newRoom.Bottom = (uint) ReadNum(ref reader);
-	newRoom.GravityX = ReadFloat(ref reader);
-	newRoom.GravityY = ReadFloat(ref reader);
-	newRoom.MetersPerPixel = ReadFloat(ref reader);
+    newRoom.Flags = (UndertaleRoom.RoomEntryFlags) ReadNum(ref reader);
+    newRoom.World = ReadBool(ref reader);
+    newRoom.Top = (uint) ReadNum(ref reader);
+    newRoom.Left = (uint) ReadNum(ref reader);
+    newRoom.Right = (uint) ReadNum(ref reader);
+    newRoom.Bottom = (uint) ReadNum(ref reader);
+    newRoom.GravityX = ReadFloat(ref reader);
+    newRoom.GravityY = ReadFloat(ref reader);
+    newRoom.MetersPerPixel = ReadFloat(ref reader);
 
-	newRoom.Caption = (caption == null) ? null : new UndertaleString(caption);
+    newRoom.Caption = (caption == null) ? null : new UndertaleString(caption);
 
-	if ((newRoom.Caption != null) && !Data.Strings.Any(s => s == newRoom.Caption))
-		Data.Strings.Add(newRoom.Caption);
+    if ((newRoom.Caption != null) && !Data.Strings.Any(s => s == newRoom.Caption))
+        Data.Strings.Add(newRoom.Caption);
 
-	newRoom.CreationCodeId = (ccIdName == null) ? null : Data.Code.ByName(ccIdName);
+    newRoom.CreationCodeId = (ccIdName == null) ? null : Data.Code.ByName(ccIdName);
 }
 
 void ReadName(ref Utf8JsonReader reader)
 {
-	string name = ReadString(ref reader);
-	if (name == null)
-		throw new Exception("ERROR: Object name was null - object name must be defined!");
+    string name = ReadString(ref reader);
+    if (name == null)
+        throw new Exception("ERROR: Object name was null - object name must be defined!");
 
-	if (Data.Rooms.ByName(name) != null)
-	{
-		newRoom = Data.Rooms.ByName(name);
-	}
-	else
-	{
-		newRoom = new UndertaleRoom();
-		newRoom.Name = new UndertaleString(name);
-		Data.Strings.Add(newRoom.Name);
-	}
+    if (Data.Rooms.ByName(name) != null)
+    {
+        newRoom = Data.Rooms.ByName(name);
+    }
+    else
+    {
+        newRoom = new UndertaleRoom();
+        newRoom.Name = new UndertaleString(name);
+        Data.Strings.Add(newRoom.Name);
+    }
 }
 
 void ClearRoomLists()
 {
-	newRoom.Backgrounds.Clear();
-	newRoom.Views.Clear();
-	newRoom.GameObjects.Clear();
-	newRoom.Tiles.Clear();
-	newRoom.Layers.Clear();
+    newRoom.Backgrounds.Clear();
+    newRoom.Views.Clear();
+    newRoom.GameObjects.Clear();
+    newRoom.Tiles.Clear();
+    newRoom.Layers.Clear();
 }
 
 void ReadBackgrounds(ref Utf8JsonReader reader)
 {
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.StartObject)
-		{
-			UndertaleRoom.Background newBg = new UndertaleRoom.Background();
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            UndertaleRoom.Background newBg = new UndertaleRoom.Background();
 
-			newBg.ParentRoom = newRoom;
+            newBg.ParentRoom = newRoom;
 
-			newBg.CalcScaleX = ReadFloat(ref reader);
-			newBg.CalcScaleY = ReadFloat(ref reader);
-			newBg.Enabled = ReadBool(ref reader);
-			newBg.Foreground = ReadBool(ref reader);
-			string bgDefName = ReadString(ref reader);
-			newBg.X = (int) ReadNum(ref reader);
-			newBg.Y = (int) ReadNum(ref reader);
-			newBg.TileX = (int) ReadNum(ref reader);
-			newBg.TileY = (int) ReadNum(ref reader);
-			newBg.SpeedX = (int) ReadNum(ref reader);
-			newBg.SpeedY = (int) ReadNum(ref reader);
-			newBg.Stretch = ReadBool(ref reader);
+            newBg.CalcScaleX = ReadFloat(ref reader);
+            newBg.CalcScaleY = ReadFloat(ref reader);
+            newBg.Enabled = ReadBool(ref reader);
+            newBg.Foreground = ReadBool(ref reader);
+            string bgDefName = ReadString(ref reader);
+            newBg.X = (int) ReadNum(ref reader);
+            newBg.Y = (int) ReadNum(ref reader);
+            newBg.TileX = (int) ReadNum(ref reader);
+            newBg.TileY = (int) ReadNum(ref reader);
+            newBg.SpeedX = (int) ReadNum(ref reader);
+            newBg.SpeedY = (int) ReadNum(ref reader);
+            newBg.Stretch = ReadBool(ref reader);
 
-			newBg.BackgroundDefinition = (bgDefName == null) ? null : Data.Backgrounds.ByName(bgDefName);
+            newBg.BackgroundDefinition = (bgDefName == null) ? null : Data.Backgrounds.ByName(bgDefName);
 
-			ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+            ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
 
-			newRoom.Backgrounds.Add(newBg);
-			continue;
-		}
+            newRoom.Backgrounds.Add(newBg);
+            continue;
+        }
 
-		if (reader.TokenType == JsonTokenType.EndArray)
-			break;
+        if (reader.TokenType == JsonTokenType.EndArray)
+            break;
 
-		throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
-	}
+        throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
+    }
 }
 
 void ReadViews(ref Utf8JsonReader reader)
 {
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.StartObject)
-		{
-			UndertaleRoom.View newView = new UndertaleRoom.View();
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            UndertaleRoom.View newView = new UndertaleRoom.View();
 
-			newView.Enabled = ReadBool(ref reader);
-			newView.ViewX = (int) ReadNum(ref reader);
-			newView.ViewY = (int) ReadNum(ref reader);
-			newView.ViewWidth = (int) ReadNum(ref reader);
-			newView.ViewHeight = (int) ReadNum(ref reader);
-			newView.PortX = (int) ReadNum(ref reader);
-			newView.PortY = (int) ReadNum(ref reader);
-			newView.PortWidth = (int) ReadNum(ref reader);
-			newView.PortHeight = (int) ReadNum(ref reader);
-			newView.BorderX = (uint) ReadNum(ref reader);
-			newView.BorderY = (uint) ReadNum(ref reader);
-			newView.SpeedX = (int) ReadNum(ref reader);
-			newView.SpeedY = (int) ReadNum(ref reader);
-			string objIdName = ReadString(ref reader);
+            newView.Enabled = ReadBool(ref reader);
+            newView.ViewX = (int) ReadNum(ref reader);
+            newView.ViewY = (int) ReadNum(ref reader);
+            newView.ViewWidth = (int) ReadNum(ref reader);
+            newView.ViewHeight = (int) ReadNum(ref reader);
+            newView.PortX = (int) ReadNum(ref reader);
+            newView.PortY = (int) ReadNum(ref reader);
+            newView.PortWidth = (int) ReadNum(ref reader);
+            newView.PortHeight = (int) ReadNum(ref reader);
+            newView.BorderX = (uint) ReadNum(ref reader);
+            newView.BorderY = (uint) ReadNum(ref reader);
+            newView.SpeedX = (int) ReadNum(ref reader);
+            newView.SpeedY = (int) ReadNum(ref reader);
+            string objIdName = ReadString(ref reader);
 
-			newView.ObjectId = (objIdName == null) ? null : Data.GameObjects.ByName(objIdName);
+            newView.ObjectId = (objIdName == null) ? null : Data.GameObjects.ByName(objIdName);
 
-			ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+            ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
 
-			newRoom.Views.Add(newView);
-			continue;
-		}
+            newRoom.Views.Add(newView);
+            continue;
+        }
 
-		if (reader.TokenType == JsonTokenType.EndArray)
-			break;
+        if (reader.TokenType == JsonTokenType.EndArray)
+            break;
 
-		throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
-	}
+        throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
+    }
 }
 
 void ReadGameObjects(ref Utf8JsonReader reader)
 {
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.StartObject)
-		{
-			UndertaleRoom.GameObject newObj = new UndertaleRoom.GameObject();
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            UndertaleRoom.GameObject newObj = new UndertaleRoom.GameObject();
 
-			newObj.X = (int) ReadNum(ref reader);
-			newObj.Y = (int) ReadNum(ref reader);
+            newObj.X = (int) ReadNum(ref reader);
+            newObj.Y = (int) ReadNum(ref reader);
 
-			string objDefName = ReadString(ref reader);
+            string objDefName = ReadString(ref reader);
 
-			newObj.InstanceID = (uint) ReadNum(ref reader);
+            newObj.InstanceID = (uint) ReadNum(ref reader);
 
-			string ccIdName = ReadString(ref reader);
+            string ccIdName = ReadString(ref reader);
 
-			newObj.ScaleX = ReadFloat(ref reader);
-			newObj.ScaleY = ReadFloat(ref reader);
-			newObj.Color = (uint) ReadNum(ref reader);
-			newObj.Rotation = ReadFloat(ref reader);
+            newObj.ScaleX = ReadFloat(ref reader);
+            newObj.ScaleY = ReadFloat(ref reader);
+            newObj.Color = (uint) ReadNum(ref reader);
+            newObj.Rotation = ReadFloat(ref reader);
 
-			string preCcIdName = ReadString(ref reader);
+            string preCcIdName = ReadString(ref reader);
 
-			newObj.ImageSpeed = ReadFloat(ref reader);
-			newObj.ImageIndex = (int) ReadNum(ref reader);
+            newObj.ImageSpeed = ReadFloat(ref reader);
+            newObj.ImageIndex = (int) ReadNum(ref reader);
 
-			newObj.ObjectDefinition = (objDefName == null) ? null : Data.GameObjects.ByName(objDefName);
-			newObj.CreationCode = (ccIdName == null) ? null : Data.Code.ByName(ccIdName);
-			newObj.PreCreateCode = (preCcIdName == null) ? null : Data.Code.ByName(preCcIdName);
+            newObj.ObjectDefinition = (objDefName == null) ? null : Data.GameObjects.ByName(objDefName);
+            newObj.CreationCode = (ccIdName == null) ? null : Data.Code.ByName(ccIdName);
+            newObj.PreCreateCode = (preCcIdName == null) ? null : Data.Code.ByName(preCcIdName);
 
-			ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+            ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
 
-			newRoom.GameObjects.Add(newObj);
-			continue;
-		}
+            newRoom.GameObjects.Add(newObj);
+            continue;
+        }
 
-		if (reader.TokenType == JsonTokenType.EndArray)
-			break;
+        if (reader.TokenType == JsonTokenType.EndArray)
+            break;
 
-		throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
-	}
+        throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
+    }
 }
 
 void ReadTiles(ref Utf8JsonReader reader)
 {
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.StartObject)
-		{
-			UndertaleRoom.Tile newTile = new UndertaleRoom.Tile();
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            UndertaleRoom.Tile newTile = new UndertaleRoom.Tile();
 
-			newTile._SpriteMode = ReadBool(ref reader);
-			newTile.X = (int) ReadNum(ref reader);
-			newTile.Y = (int) ReadNum(ref reader);
+            newTile._SpriteMode = ReadBool(ref reader);
+            newTile.X = (int) ReadNum(ref reader);
+            newTile.Y = (int) ReadNum(ref reader);
 
-			string bgDefName = ReadString(ref reader);
-			string sprDefName = ReadString(ref reader);
+            string bgDefName = ReadString(ref reader);
+            string sprDefName = ReadString(ref reader);
 
-			newTile.SourceX = (uint) ReadNum(ref reader);
-			newTile.SourceY = (uint) ReadNum(ref reader);
-			newTile.Width = (uint) ReadNum(ref reader);
-			newTile.Height = (uint) ReadNum(ref reader);
-			newTile.TileDepth = (int) ReadNum(ref reader);
-			newTile.InstanceID = (uint) ReadNum(ref reader);
-			newTile.ScaleX = ReadFloat(ref reader);
-			newTile.ScaleY = ReadFloat(ref reader);
-			newTile.Color = (uint) ReadNum(ref reader);
+            newTile.SourceX = (uint) ReadNum(ref reader);
+            newTile.SourceY = (uint) ReadNum(ref reader);
+            newTile.Width = (uint) ReadNum(ref reader);
+            newTile.Height = (uint) ReadNum(ref reader);
+            newTile.TileDepth = (int) ReadNum(ref reader);
+            newTile.InstanceID = (uint) ReadNum(ref reader);
+            newTile.ScaleX = ReadFloat(ref reader);
+            newTile.ScaleY = ReadFloat(ref reader);
+            newTile.Color = (uint) ReadNum(ref reader);
 
-			newTile.BackgroundDefinition = (bgDefName == null) ? null : Data.Backgrounds.ByName(bgDefName);
-			newTile.SpriteDefinition = (sprDefName == null) ? null : Data.Sprites.ByName(sprDefName);
+            newTile.BackgroundDefinition = (bgDefName == null) ? null : Data.Backgrounds.ByName(bgDefName);
+            newTile.SpriteDefinition = (sprDefName == null) ? null : Data.Sprites.ByName(sprDefName);
 
-			ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+            ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
 
-			newRoom.Tiles.Add(newTile);
-			continue;
-		}
+            newRoom.Tiles.Add(newTile);
+            continue;
+        }
 
-		if (reader.TokenType == JsonTokenType.EndArray)
-			break;
+        if (reader.TokenType == JsonTokenType.EndArray)
+            break;
 
-		throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
-	}
+        throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
+    }
 }
 
 void ReadLayers(ref Utf8JsonReader reader)
 {
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.StartObject)
-		{
-			UndertaleRoom.Layer newLayer = new UndertaleRoom.Layer();
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            UndertaleRoom.Layer newLayer = new UndertaleRoom.Layer();
 
-			string layerName = ReadString(ref reader);
+            string layerName = ReadString(ref reader);
 
-			newLayer.LayerId = (uint) ReadNum(ref reader);
-			newLayer.LayerType = (UndertaleRoom.LayerType) ReadNum(ref reader);
-			newLayer.LayerDepth = (int) ReadNum(ref reader);
-			newLayer.XOffset = ReadFloat(ref reader);
-			newLayer.YOffset = ReadFloat(ref reader);
-			newLayer.HSpeed = ReadFloat(ref reader);
-			newLayer.VSpeed = ReadFloat(ref reader);
-			newLayer.IsVisible = ReadBool(ref reader);
+            newLayer.LayerId = (uint) ReadNum(ref reader);
+            newLayer.LayerType = (UndertaleRoom.LayerType) ReadNum(ref reader);
+            newLayer.LayerDepth = (int) ReadNum(ref reader);
+            newLayer.XOffset = ReadFloat(ref reader);
+            newLayer.YOffset = ReadFloat(ref reader);
+            newLayer.HSpeed = ReadFloat(ref reader);
+            newLayer.VSpeed = ReadFloat(ref reader);
+            newLayer.IsVisible = ReadBool(ref reader);
 
 
-			newLayer.LayerName = (layerName == null) ? null : new UndertaleString(layerName);
+            newLayer.LayerName = (layerName == null) ? null : new UndertaleString(layerName);
 
-			if ((layerName != null) && !Data.Strings.Any(s => s == newLayer.LayerName))
-				Data.Strings.Add(newLayer.LayerName);
+            if ((layerName != null) && !Data.Strings.Any(s => s == newLayer.LayerName))
+                Data.Strings.Add(newLayer.LayerName);
 
-			switch (newLayer.LayerType)
-			{
-				case UndertaleRoom.LayerType.Background:
-					ReadBackgroundLayer(ref reader, newLayer);
-					break;
-				case UndertaleRoom.LayerType.Instances:
-					ReadInstancesLayer(ref reader, newLayer);
-					break;
-				case UndertaleRoom.LayerType.Assets:
-					ReadAssetsLayer(ref reader, newLayer);
-					break;
-				case UndertaleRoom.LayerType.Tiles:
-					ReadTilesLayer(ref reader, newLayer);
-					break;
-				default:
-					throw new Exception("ERROR: Invalid value for layer data type.");
-			}
+            switch (newLayer.LayerType)
+            {
+                case UndertaleRoom.LayerType.Background:
+                    ReadBackgroundLayer(ref reader, newLayer);
+                    break;
+                case UndertaleRoom.LayerType.Instances:
+                    ReadInstancesLayer(ref reader, newLayer);
+                    break;
+                case UndertaleRoom.LayerType.Assets:
+                    ReadAssetsLayer(ref reader, newLayer);
+                    break;
+                case UndertaleRoom.LayerType.Tiles:
+                    ReadTilesLayer(ref reader, newLayer);
+                    break;
+                default:
+                    throw new Exception("ERROR: Invalid value for layer data type.");
+            }
 
-			ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+            ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
 
-			newRoom.Layers.Add(newLayer);
-			continue;
-		}
+            newRoom.Layers.Add(newLayer);
+            continue;
+        }
 
-		if (reader.TokenType == JsonTokenType.EndArray)
-			break;
+        if (reader.TokenType == JsonTokenType.EndArray)
+            break;
 
-		throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
-	}
+        throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
+    }
 }
 
 void ReadBackgroundLayer(ref Utf8JsonReader reader, UndertaleRoom.Layer newLayer)
 {
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartObject);
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartObject);
 
-	UndertaleRoom.Layer.LayerBackgroundData newLayerData = new UndertaleRoom.Layer.LayerBackgroundData();
+    UndertaleRoom.Layer.LayerBackgroundData newLayerData = new UndertaleRoom.Layer.LayerBackgroundData();
 
-	newLayerData.CalcScaleX = ReadFloat(ref reader);
-	newLayerData.CalcScaleY = ReadFloat(ref reader);
-	newLayerData.Visible = ReadBool(ref reader);
-	newLayerData.Foreground = ReadBool(ref reader);
+    newLayerData.CalcScaleX = ReadFloat(ref reader);
+    newLayerData.CalcScaleY = ReadFloat(ref reader);
+    newLayerData.Visible = ReadBool(ref reader);
+    newLayerData.Foreground = ReadBool(ref reader);
 
-	string spriteName = ReadString(ref reader);
+    string spriteName = ReadString(ref reader);
 
-	newLayerData.TiledHorizontally = ReadBool(ref reader);
-	newLayerData.TiledVertically = ReadBool(ref reader);
-	newLayerData.Stretch = ReadBool(ref reader);
-	newLayerData.Color = (uint) ReadNum(ref reader);
-	newLayerData.FirstFrame = ReadFloat(ref reader);
-	newLayerData.AnimationSpeed = ReadFloat(ref reader);
-	newLayerData.AnimationSpeedType = (AnimationSpeedType) ReadNum(ref reader);
+    newLayerData.TiledHorizontally = ReadBool(ref reader);
+    newLayerData.TiledVertically = ReadBool(ref reader);
+    newLayerData.Stretch = ReadBool(ref reader);
+    newLayerData.Color = (uint) ReadNum(ref reader);
+    newLayerData.FirstFrame = ReadFloat(ref reader);
+    newLayerData.AnimationSpeed = ReadFloat(ref reader);
+    newLayerData.AnimationSpeedType = (AnimationSpeedType) ReadNum(ref reader);
 
-	newLayerData.Sprite = (spriteName == null) ? null : Data.Sprites.ByName(spriteName);
+    newLayerData.Sprite = (spriteName == null) ? null : Data.Sprites.ByName(spriteName);
 
-	newLayerData.ParentLayer = newLayer;
+    newLayerData.ParentLayer = newLayer;
 
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
 
-	newLayer.Data = newLayerData;
+    newLayer.Data = newLayerData;
 }
 
 void ReadInstancesLayer(ref Utf8JsonReader reader, UndertaleRoom.Layer newLayer)
 {
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartObject);
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.PropertyName)
-			continue;
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartObject);
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.PropertyName)
+            continue;
 
-		if (reader.TokenType != JsonTokenType.StartArray)
-			throw new Exception("ERROR: Did not correctly stop reading instances layer");
+        if (reader.TokenType != JsonTokenType.StartArray)
+            throw new Exception("ERROR: Did not correctly stop reading instances layer");
 
-		UndertaleRoom.Layer.LayerInstancesData newLayerData = new UndertaleRoom.Layer.LayerInstancesData();
+        UndertaleRoom.Layer.LayerInstancesData newLayerData = new UndertaleRoom.Layer.LayerInstancesData();
 
-		while (reader.Read())
-		{
-			if (reader.TokenType == JsonTokenType.PropertyName)
-				continue;
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.PropertyName)
+                continue;
 
-			if (reader.TokenType == JsonTokenType.StartObject)
-			{
-				UndertaleRoom.GameObject newObj = new UndertaleRoom.GameObject();
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                UndertaleRoom.GameObject newObj = new UndertaleRoom.GameObject();
 
-				newObj.X = (int) ReadNum(ref reader);
-				newObj.Y = (int) ReadNum(ref reader);
+                newObj.X = (int) ReadNum(ref reader);
+                newObj.Y = (int) ReadNum(ref reader);
 
-				string objDefName = ReadString(ref reader);
+                string objDefName = ReadString(ref reader);
 
-				newObj.InstanceID = (uint) ReadNum(ref reader);
+                newObj.InstanceID = (uint) ReadNum(ref reader);
 
-				string ccIdName = ReadString(ref reader);
+                string ccIdName = ReadString(ref reader);
 
-				newObj.ScaleX = ReadFloat(ref reader);
-				newObj.ScaleY = ReadFloat(ref reader);
-				newObj.Color = (uint) ReadNum(ref reader);
-				newObj.Rotation = ReadFloat(ref reader);
+                newObj.ScaleX = ReadFloat(ref reader);
+                newObj.ScaleY = ReadFloat(ref reader);
+                newObj.Color = (uint) ReadNum(ref reader);
+                newObj.Rotation = ReadFloat(ref reader);
 
-				string preCcIdName = ReadString(ref reader);
+                string preCcIdName = ReadString(ref reader);
 
-				newObj.ImageSpeed = ReadFloat(ref reader);
-				newObj.ImageIndex = (int) ReadNum(ref reader);
+                newObj.ImageSpeed = ReadFloat(ref reader);
+                newObj.ImageIndex = (int) ReadNum(ref reader);
 
-				newObj.ObjectDefinition = (objDefName == null) ? null : Data.GameObjects.ByName(objDefName);
+                newObj.ObjectDefinition = (objDefName == null) ? null : Data.GameObjects.ByName(objDefName);
 
-				newObj.CreationCode = (ccIdName == null) ? null : Data.Code.ByName(ccIdName);
+                newObj.CreationCode = (ccIdName == null) ? null : Data.Code.ByName(ccIdName);
 
-				newObj.PreCreateCode = (preCcIdName == null) ? null : Data.Code.ByName(preCcIdName);
+                newObj.PreCreateCode = (preCcIdName == null) ? null : Data.Code.ByName(preCcIdName);
 
-				ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+                ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
 
-				newLayerData.Instances.Add(newObj);
-				continue;
-			}
+                newLayerData.Instances.Add(newObj);
+                continue;
+            }
 
-			if (reader.TokenType == JsonTokenType.EndArray)
-				break;
+            if (reader.TokenType == JsonTokenType.EndArray)
+                break;
 
-			throw new Exception("ERROR: Did not correctly stop reading instances in instance layer");
-		}
+            throw new Exception("ERROR: Did not correctly stop reading instances in instance layer");
+        }
 
-		ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+        ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
 
-		newLayer.Data = newLayerData;
+        newLayer.Data = newLayerData;
 
-		return;
+        return;
 
-	}
+    }
 }
 
 void ReadAssetsLayer(ref Utf8JsonReader reader, UndertaleRoom.Layer newLayer)
 {
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartObject);
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
-	UndertaleRoom.Layer.LayerAssetsData newLayerData = new UndertaleRoom.Layer.LayerAssetsData();
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartObject);
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
+    UndertaleRoom.Layer.LayerAssetsData newLayerData = new UndertaleRoom.Layer.LayerAssetsData();
 
-	newLayerData.LegacyTiles = new UndertalePointerList<UndertaleRoom.Tile>();
-	newLayerData.Sprites = new UndertalePointerList<UndertaleRoom.SpriteInstance>();
-	newLayerData.Sequences = new UndertalePointerList<UndertaleRoom.SequenceInstance>();
-	newLayerData.NineSlices = new UndertalePointerList<UndertaleRoom.SpriteInstance>();
+    newLayerData.LegacyTiles = new UndertalePointerList<UndertaleRoom.Tile>();
+    newLayerData.Sprites = new UndertalePointerList<UndertaleRoom.SpriteInstance>();
+    newLayerData.Sequences = new UndertalePointerList<UndertaleRoom.SequenceInstance>();
+    newLayerData.NineSlices = new UndertalePointerList<UndertaleRoom.SpriteInstance>();
 
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.StartObject)
-		{
-			UndertaleRoom.Tile newTile = new UndertaleRoom.Tile();
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            UndertaleRoom.Tile newTile = new UndertaleRoom.Tile();
 
-			newTile._SpriteMode = ReadBool(ref reader);
-			newTile.X = (int) ReadNum(ref reader);
-			newTile.Y = (int) ReadNum(ref reader);
+            newTile._SpriteMode = ReadBool(ref reader);
+            newTile.X = (int) ReadNum(ref reader);
+            newTile.Y = (int) ReadNum(ref reader);
 
-			string bgDefName = ReadString(ref reader);
-			string sprDefName = ReadString(ref reader);
+            string bgDefName = ReadString(ref reader);
+            string sprDefName = ReadString(ref reader);
 
-			newTile.SourceX = (uint) ReadNum(ref reader);
-			newTile.SourceY = (uint) ReadNum(ref reader);
-			newTile.Width = (uint) ReadNum(ref reader);
-			newTile.Height = (uint) ReadNum(ref reader);
-			newTile.TileDepth = (int) ReadNum(ref reader);
-			newTile.InstanceID = (uint) ReadNum(ref reader);
-			newTile.ScaleX = ReadFloat(ref reader);
-			newTile.ScaleY = ReadFloat(ref reader);
-			newTile.Color = (uint) ReadNum(ref reader);
+            newTile.SourceX = (uint) ReadNum(ref reader);
+            newTile.SourceY = (uint) ReadNum(ref reader);
+            newTile.Width = (uint) ReadNum(ref reader);
+            newTile.Height = (uint) ReadNum(ref reader);
+            newTile.TileDepth = (int) ReadNum(ref reader);
+            newTile.InstanceID = (uint) ReadNum(ref reader);
+            newTile.ScaleX = ReadFloat(ref reader);
+            newTile.ScaleY = ReadFloat(ref reader);
+            newTile.Color = (uint) ReadNum(ref reader);
 
-			newTile.BackgroundDefinition = (bgDefName == null) ? null : Data.Backgrounds.ByName(bgDefName);
+            newTile.BackgroundDefinition = (bgDefName == null) ? null : Data.Backgrounds.ByName(bgDefName);
 
-			newTile.SpriteDefinition = (sprDefName == null) ? null : Data.Sprites.ByName(sprDefName);
+            newTile.SpriteDefinition = (sprDefName == null) ? null : Data.Sprites.ByName(sprDefName);
 
-			ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+            ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
 
-			newLayerData.LegacyTiles.Add(newTile);
-			continue;
-		}
+            newLayerData.LegacyTiles.Add(newTile);
+            continue;
+        }
 
-		if (reader.TokenType == JsonTokenType.EndArray)
-			break;
+        if (reader.TokenType == JsonTokenType.EndArray)
+            break;
 
-		throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
-	}
+        throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
+    }
 
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.PropertyName)
-			continue;
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.PropertyName)
+            continue;
 
-		if (reader.TokenType == JsonTokenType.StartObject)
-		{
-			UndertaleRoom.SpriteInstance newSpr = new UndertaleRoom.SpriteInstance();
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            UndertaleRoom.SpriteInstance newSpr = new UndertaleRoom.SpriteInstance();
 
-			string name = ReadString(ref reader);
-			string spriteName = ReadString(ref reader);
+            string name = ReadString(ref reader);
+            string spriteName = ReadString(ref reader);
 
-			newSpr.X = (int) ReadNum(ref reader);
-			newSpr.Y = (int) ReadNum(ref reader);
-			newSpr.ScaleX = ReadFloat(ref reader);
-			newSpr.ScaleY = ReadFloat(ref reader);
-			newSpr.Color = (uint) ReadNum(ref reader);
-			newSpr.AnimationSpeed = ReadFloat(ref reader);
-			newSpr.AnimationSpeedType = (AnimationSpeedType) ReadNum(ref reader);
-			newSpr.FrameIndex = ReadFloat(ref reader);
-			newSpr.Rotation = ReadFloat(ref reader);
+            newSpr.X = (int) ReadNum(ref reader);
+            newSpr.Y = (int) ReadNum(ref reader);
+            newSpr.ScaleX = ReadFloat(ref reader);
+            newSpr.ScaleY = ReadFloat(ref reader);
+            newSpr.Color = (uint) ReadNum(ref reader);
+            newSpr.AnimationSpeed = ReadFloat(ref reader);
+            newSpr.AnimationSpeedType = (AnimationSpeedType) ReadNum(ref reader);
+            newSpr.FrameIndex = ReadFloat(ref reader);
+            newSpr.Rotation = ReadFloat(ref reader);
 
-			newSpr.Name = (name == null) ? null : new UndertaleString(name);
+            newSpr.Name = (name == null) ? null : new UndertaleString(name);
 
-			if ((name != null) && !Data.Strings.Any(s => s == newSpr.Name))
-				Data.Strings.Add(newSpr.Name);
+            if ((name != null) && !Data.Strings.Any(s => s == newSpr.Name))
+                Data.Strings.Add(newSpr.Name);
 
-			newSpr.Sprite = (spriteName == null) ? null : Data.Sprites.ByName(spriteName);
+            newSpr.Sprite = (spriteName == null) ? null : Data.Sprites.ByName(spriteName);
 
-			ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+            ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
 
-			newLayerData.Sprites.Add(newSpr);
-			continue;
-		}
+            newLayerData.Sprites.Add(newSpr);
+            continue;
+        }
 
-		if (reader.TokenType == JsonTokenType.EndArray)
-			break;
+        if (reader.TokenType == JsonTokenType.EndArray)
+            break;
 
-		throw new Exception("ERROR: Did not correctly stop reading instances in instance layer");
-	}
+        throw new Exception("ERROR: Did not correctly stop reading instances in instance layer");
+    }
 
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.PropertyName)
-			continue;
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.PropertyName)
+            continue;
 
-		if (reader.TokenType == JsonTokenType.StartObject)
-		{
-			UndertaleRoom.SequenceInstance newSeq = new UndertaleRoom.SequenceInstance();
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            UndertaleRoom.SequenceInstance newSeq = new UndertaleRoom.SequenceInstance();
 
-			string name = ReadString(ref reader);
-			string sequenceName = ReadString(ref reader);
+            string name = ReadString(ref reader);
+            string sequenceName = ReadString(ref reader);
 
-			newSeq.X = (int) ReadNum(ref reader);
-			newSeq.Y = (int) ReadNum(ref reader);
-			newSeq.ScaleX = ReadFloat(ref reader);
-			newSeq.ScaleY = ReadFloat(ref reader);
-			newSeq.Color = (uint) ReadNum(ref reader);
-			newSeq.AnimationSpeed = ReadFloat(ref reader);
-			newSeq.AnimationSpeedType = (AnimationSpeedType) ReadNum(ref reader);
-			newSeq.FrameIndex = ReadFloat(ref reader);
-			newSeq.Rotation = ReadFloat(ref reader);
+            newSeq.X = (int) ReadNum(ref reader);
+            newSeq.Y = (int) ReadNum(ref reader);
+            newSeq.ScaleX = ReadFloat(ref reader);
+            newSeq.ScaleY = ReadFloat(ref reader);
+            newSeq.Color = (uint) ReadNum(ref reader);
+            newSeq.AnimationSpeed = ReadFloat(ref reader);
+            newSeq.AnimationSpeedType = (AnimationSpeedType) ReadNum(ref reader);
+            newSeq.FrameIndex = ReadFloat(ref reader);
+            newSeq.Rotation = ReadFloat(ref reader);
 
 
-			newSeq.Name = (name == null) ? null : new UndertaleString(name);
+            newSeq.Name = (name == null) ? null : new UndertaleString(name);
 
-			if ((name != null) && !Data.Strings.Any(s => s == newSeq.Name))
-				Data.Strings.Add(newSeq.Name);
+            if ((name != null) && !Data.Strings.Any(s => s == newSeq.Name))
+                Data.Strings.Add(newSeq.Name);
 
-			newSeq.Sequence = (sequenceName == null) ? null : Data.Sequences.ByName(sequenceName);
+            newSeq.Sequence = (sequenceName == null) ? null : Data.Sequences.ByName(sequenceName);
 
-			ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+            ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
 
-			newLayerData.Sequences.Add(newSeq);
-			continue;
-		}
+            newLayerData.Sequences.Add(newSeq);
+            continue;
+        }
 
-		if (reader.TokenType == JsonTokenType.EndArray)
-			break;
+        if (reader.TokenType == JsonTokenType.EndArray)
+            break;
 
-		throw new Exception("ERROR: Did not correctly stop reading instances in instance layer");
-	}
+        throw new Exception("ERROR: Did not correctly stop reading instances in instance layer");
+    }
 
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.PropertyName)
-			continue;
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.PropertyName)
+            continue;
 
-		if (reader.TokenType == JsonTokenType.StartObject)
-		{
-			UndertaleRoom.SpriteInstance newSpr = new UndertaleRoom.SpriteInstance();
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            UndertaleRoom.SpriteInstance newSpr = new UndertaleRoom.SpriteInstance();
 
-			string name = ReadString(ref reader);
-			string spriteName = ReadString(ref reader);
+            string name = ReadString(ref reader);
+            string spriteName = ReadString(ref reader);
 
-			newSpr.X = (int) ReadNum(ref reader);
-			newSpr.Y = (int) ReadNum(ref reader);
-			newSpr.ScaleX = ReadFloat(ref reader);
-			newSpr.ScaleY = ReadFloat(ref reader);
-			newSpr.Color = (uint) ReadNum(ref reader);
-			newSpr.AnimationSpeed = ReadFloat(ref reader);
-			newSpr.AnimationSpeedType = (AnimationSpeedType) ReadNum(ref reader);
-			newSpr.FrameIndex = ReadFloat(ref reader);
-			newSpr.Rotation = ReadFloat(ref reader);
+            newSpr.X = (int) ReadNum(ref reader);
+            newSpr.Y = (int) ReadNum(ref reader);
+            newSpr.ScaleX = ReadFloat(ref reader);
+            newSpr.ScaleY = ReadFloat(ref reader);
+            newSpr.Color = (uint) ReadNum(ref reader);
+            newSpr.AnimationSpeed = ReadFloat(ref reader);
+            newSpr.AnimationSpeedType = (AnimationSpeedType) ReadNum(ref reader);
+            newSpr.FrameIndex = ReadFloat(ref reader);
+            newSpr.Rotation = ReadFloat(ref reader);
 
-			newSpr.Name = (name == null) ? null : new UndertaleString(name);
+            newSpr.Name = (name == null) ? null : new UndertaleString(name);
 
-			if ((name != null) && !Data.Strings.Any(s => s == newSpr.Name))
-				Data.Strings.Add(newSpr.Name);
+            if ((name != null) && !Data.Strings.Any(s => s == newSpr.Name))
+                Data.Strings.Add(newSpr.Name);
 
-			newSpr.Sprite = spriteName == null ? null : Data.Sprites.ByName(spriteName);
+            newSpr.Sprite = spriteName == null ? null : Data.Sprites.ByName(spriteName);
 
-			ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+            ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
 
-			newLayerData.NineSlices.Add(newSpr);
-			continue;
-		}
+            newLayerData.NineSlices.Add(newSpr);
+            continue;
+        }
 
-		if (reader.TokenType == JsonTokenType.EndArray)
-			break;
+        if (reader.TokenType == JsonTokenType.EndArray)
+            break;
 
-		throw new Exception("ERROR: Did not correctly stop reading instances in instance layer");
-	}
+        throw new Exception("ERROR: Did not correctly stop reading instances in instance layer");
+    }
 
-	newLayer.Data = newLayerData;
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+    newLayer.Data = newLayerData;
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
 }
 
 void ReadTilesLayer(ref Utf8JsonReader reader, UndertaleRoom.Layer newLayer)
 {
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartObject);
-	UndertaleRoom.Layer.LayerTilesData newLayerData = new UndertaleRoom.Layer.LayerTilesData();
-	newLayerData.TilesX = (uint) ReadNum(ref reader);
-	newLayerData.TilesY = (uint) ReadNum(ref reader);
-	uint[][] tileIds = new uint[newLayerData.TilesY][];
-	for (int i = 0; i < newLayerData.TilesY; i++)
-	{
-		tileIds[i] = new uint[newLayerData.TilesX];
-	}
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartObject);
+    UndertaleRoom.Layer.LayerTilesData newLayerData = new UndertaleRoom.Layer.LayerTilesData();
 
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
-	for (int y = 0; y < newLayerData.TilesY; y++)
-	{
-		ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
-		for (int x = 0; x < newLayerData.TilesX; x++)
-		{
-			ReadAnticipateJSONObject(ref reader, JsonTokenType.StartObject);
-			(tileIds[y])[x] = (uint) ReadNum(ref reader);
-			ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
-		}
+    string backgroundName = ReadString(ref reader);
+    
+    newLayerData.TilesX = (uint) ReadNum(ref reader);
+    newLayerData.TilesY = (uint) ReadNum(ref reader);
 
-		ReadAnticipateJSONObject(ref reader, JsonTokenType.EndArray);
-	}
+    newLayerData.Background = (backgroundName == null) ? null : Data.Backgrounds.ByName(backgroundName);
 
-	newLayerData.TileData = tileIds;
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.EndArray);
-	ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+    uint[][] tileIds = new uint[newLayerData.TilesY][];
+    for (int i = 0; i < newLayerData.TilesY; i++)
+    {
+        tileIds[i] = new uint[newLayerData.TilesX];
+    }
 
-	newLayer.Data = newLayerData;
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
+    for (int y = 0; y < newLayerData.TilesY; y++)
+    {
+        ReadAnticipateJSONObject(ref reader, JsonTokenType.StartArray);
+        for (int x = 0; x < newLayerData.TilesX; x++)
+        {
+            ReadAnticipateJSONObject(ref reader, JsonTokenType.StartObject);
+            (tileIds[y])[x] = (uint) ReadNum(ref reader);
+            ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+        }
+
+        ReadAnticipateJSONObject(ref reader, JsonTokenType.EndArray);
+    }
+
+    newLayerData.TileData = tileIds;
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.EndArray);
+    ReadAnticipateJSONObject(ref reader, JsonTokenType.EndObject);
+
+    newLayer.Data = newLayerData;
 }
 
 // Read tokens of specified type
 
 bool ReadBool(ref Utf8JsonReader reader)
 {
-	while (reader.Read())
-	{
-		switch (reader.TokenType)
-		{
-			case JsonTokenType.PropertyName: continue;
-			case JsonTokenType.True: return true;
-			case JsonTokenType.False: return false;
-			default: throw new Exception($"ERROR: Unexpected token type. Expected Boolean - found {reader.TokenType}");
-		}
-	}
+    while (reader.Read())
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.PropertyName: continue;
+            case JsonTokenType.True: return true;
+            case JsonTokenType.False: return false;
+            default: throw new Exception($"ERROR: Unexpected token type. Expected Boolean - found {reader.TokenType}");
+        }
+    }
 
-	throw new Exception("ERROR: Did not find value of expected type. Expected Boolean.");
+    throw new Exception("ERROR: Did not find value of expected type. Expected Boolean.");
 }
 
 long ReadNum(ref Utf8JsonReader reader)
 {
-	while (reader.Read())
-	{
-		switch (reader.TokenType)
-		{
-			case JsonTokenType.PropertyName: continue;
-			case JsonTokenType.Number: return reader.GetInt64();
-			default: throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
-		}
-	}
+    while (reader.Read())
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.PropertyName: continue;
+            case JsonTokenType.Number: return reader.GetInt64();
+            default: throw new Exception($"ERROR: Unexpected token type. Expected Integer - found {reader.TokenType}");
+        }
+    }
 
-	throw new Exception("ERROR: Did not find value of expected type. Expected Integer.");
+    throw new Exception("ERROR: Did not find value of expected type. Expected Integer.");
 }
 
 float ReadFloat(ref Utf8JsonReader reader)
 {
-	while (reader.Read())
-	{
-		switch (reader.TokenType)
-		{
-			case JsonTokenType.PropertyName: continue;
-			case JsonTokenType.Number: return reader.GetSingle();
-			default: throw new Exception($"ERROR: Unexpected token type. Expected Decimal - found {reader.TokenType}");
-		}
-	}
+    while (reader.Read())
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.PropertyName: continue;
+            case JsonTokenType.Number: return reader.GetSingle();
+            default: throw new Exception($"ERROR: Unexpected token type. Expected Decimal - found {reader.TokenType}");
+        }
+    }
 
-	throw new Exception("ERROR: Did not find value of expected type. Expected Decimal.");
+    throw new Exception("ERROR: Did not find value of expected type. Expected Decimal.");
 }
 
 string ReadString(ref Utf8JsonReader reader)
 {
-	while (reader.Read())
-	{
-		switch (reader.TokenType)
-		{
-			case JsonTokenType.PropertyName: continue;
-			case JsonTokenType.String: return reader.GetString();
-			case JsonTokenType.Null: return null;
-			default: throw new Exception($"ERROR: Unexpected token type. Expected String - found {reader.TokenType}");
-		}
-	}
+    while (reader.Read())
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.PropertyName: continue;
+            case JsonTokenType.String: return reader.GetString();
+            case JsonTokenType.Null: return null;
+            default: throw new Exception($"ERROR: Unexpected token type. Expected String - found {reader.TokenType}");
+        }
+    }
 
-	throw new Exception("ERROR: Did not find value of expected type. Expected String.");
+    throw new Exception("ERROR: Did not find value of expected type. Expected String.");
 }
 
 // Watch for certain meta-tokens
 
 void ReadAnticipateJSONObject(ref Utf8JsonReader reader, JsonTokenType allowedTokenType)
 {
-	while (reader.Read())
-	{
-		if (reader.TokenType == JsonTokenType.PropertyName)
-			continue;
-		if (reader.TokenType == allowedTokenType)
-			return;
-		throw new Exception($"ERROR: Unexpected token type. Expected {allowedTokenType} - found {reader.TokenType}");
-	}
+    while (reader.Read())
+    {
+        if (reader.TokenType == JsonTokenType.PropertyName)
+            continue;
+        if (reader.TokenType == allowedTokenType)
+            return;
+        throw new Exception($"ERROR: Unexpected token type. Expected {allowedTokenType} - found {reader.TokenType}");
+    }
 
-	throw new Exception("ERROR: Did not find value of expected type. Expected String.");
+    throw new Exception("ERROR: Did not find value of expected type. Expected String.");
 }

--- a/UndertaleModTool/Repackers/ImportRoom.csx
+++ b/UndertaleModTool/Repackers/ImportRoom.csx
@@ -11,6 +11,8 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Linq;
 
+EnsureDataLoaded();
+
 ScriptMessage("Select the Room to import");
 string roomInputPath = PromptLoadFile("Import which file", "Json Files|*.json");
 if (roomInputPath == null) throw new ScriptException("The room's path was not set.");

--- a/UndertaleModTool/Repackers/ImportRoom.csx
+++ b/UndertaleModTool/Repackers/ImportRoom.csx
@@ -62,7 +62,7 @@ void ReadMainValues(ref Utf8JsonReader reader)
     newRoom.Height = (uint) ReadNum(ref reader);
     newRoom.Speed = (uint) ReadNum(ref reader);
     newRoom.Persistent = ReadBool(ref reader);
-    newRoom.BackgroundColor = (uint) ReadNum(ref reader);
+    newRoom.BackgroundColor = (uint) (0xFF000000 | ReadNum(ref reader)); // make alpha 255 (BG color doesn't have alpha)
     newRoom.DrawBackgroundColor = ReadBool(ref reader);
 
     string ccIdName = ReadString(ref reader);

--- a/UndertaleModTool/Unpackers/ExportAllGameObjects.csx
+++ b/UndertaleModTool/Unpackers/ExportAllGameObjects.csx
@@ -6,6 +6,8 @@ using System.Text;
 using System.Text.Json;
 using UndertaleModLib.Models;
 
+EnsureDataLoaded();
+
 ScriptMessage("Select the GameObject output directory");
 string gameObjectOutputPath = PromptChooseDirectory("Export to where");
 if (gameObjectOutputPath == null) throw new ScriptException("The patch's output path was not set.");

--- a/UndertaleModTool/Unpackers/ExportAllGameObjects.csx
+++ b/UndertaleModTool/Unpackers/ExportAllGameObjects.csx
@@ -10,146 +10,139 @@ ScriptMessage("Select the GameObject output directory");
 string gameObjectOutputPath = PromptChooseDirectory("Export to where");
 if (gameObjectOutputPath == null) throw new ScriptException("The patch's output path was not set.");
 
-StreamWriter sw;
+JsonWriterOptions writerOptions = new JsonWriterOptions { Indented = true };
 foreach (UndertaleGameObject gameObject in Data.GameObjects)
 {
-	if (gameObject == null) continue;
+    if (gameObject == null) continue;
 
-	try
-	{
-		string jsonString = GameObjectToJson(gameObject);
-		sw = new StreamWriter(Path.Join(gameObjectOutputPath, gameObject.Name.Content) + ".json");
-		sw.Write(jsonString);
-	}
-	catch (Exception e)
-	{
-		throw e;
-	}
-	finally
-	{
-		if (sw != null) sw.Close();
-	}
+    try
+    {
+        WriteGameObjectToJson(gameObject);
+    }
+    catch (Exception e)
+    {
+        throw e;
+    }
 }
 
 void WriteString(Utf8JsonWriter writer, string propertyName, UndertaleString stringToWrite)
 {
-	if (stringToWrite?.Content == null)
-	    writer.WriteNull(propertyName);
-	else
-	    writer.WriteString(propertyName, stringToWrite.Content);
+    if (stringToWrite?.Content == null)
+        writer.WriteNull(propertyName);
+    else
+        writer.WriteString(propertyName, stringToWrite.Content);
 }
 
-string GameObjectToJson(UndertaleGameObject gameObject)
+void WriteGameObjectToJson(UndertaleGameObject gameObject)
 {
-	JsonWriterOptions writerOptions = new JsonWriterOptions {Indented = true};
-	using MemoryStream stream = new MemoryStream();
-	using Utf8JsonWriter writer = new Utf8JsonWriter(stream, writerOptions);
-	writer.WriteStartObject();
-	string json;
-	if (gameObject == null)
-	{
-		writer.WriteEndObject();
-		writer.Flush();
-		json = Encoding.UTF8.GetString(stream.ToArray());
-		return json;
-	}
+    using MemoryStream stream = new MemoryStream();
+    using Utf8JsonWriter writer = new Utf8JsonWriter(stream, writerOptions);
+    writer.WriteStartObject();
 
-	WriteString(writer, "name", gameObject.Name);
+    if (gameObject == null)
+    {
+        writer.WriteEndObject();
 
-	WriteString(writer, "sprite", gameObject.Sprite?.Name);
+        writer.Flush();
 
-	writer.WriteBoolean("visible", gameObject.Visible);
-	writer.WriteBoolean("solid", gameObject.Solid);
-	writer.WriteNumber("depth", gameObject.Depth);
-	writer.WriteBoolean("persistent", gameObject.Persistent);
+        File.WriteAllBytes(Path.Join(gameObjectOutputPath, gameObject.Name.Content) + ".json", stream.ToArray());
+    }
 
-	WriteString(writer, "parent_id", gameObject.ParentId?.Name);
+    WriteString(writer, "name", gameObject.Name);
 
-	WriteString(writer, "texture_mask_id", gameObject.TextureMaskId?.Name);
+    WriteString(writer, "sprite", gameObject.Sprite?.Name);
 
-	writer.WriteBoolean("uses_physics", gameObject.UsesPhysics);
-	writer.WriteBoolean("is_sensor", gameObject.IsSensor);
-	writer.WriteNumber("collision_shape", Convert.ToInt32(gameObject.CollisionShape));
-	writer.WriteNumber("density", gameObject.Density);
-	writer.WriteNumber("restitution", gameObject.Restitution);
-	writer.WriteNumber("group", gameObject.Group);
-	writer.WriteNumber("linear_damping", gameObject.LinearDamping);
-	writer.WriteNumber("angular_damping", gameObject.AngularDamping);
-	writer.WriteNumber("friction", gameObject.Friction);
-	writer.WriteBoolean("awake", gameObject.Awake);
-	writer.WriteBoolean("kinematic", gameObject.Kinematic);
+    writer.WriteBoolean("visible", gameObject.Visible);
+    writer.WriteBoolean("solid", gameObject.Solid);
+    writer.WriteNumber("depth", gameObject.Depth);
+    writer.WriteBoolean("persistent", gameObject.Persistent);
 
-	writer.WriteStartArray("physics_vertices");
-	if (gameObject.PhysicsVertices != null)
-	{
-		foreach (UndertaleGameObject.UndertalePhysicsVertex vertex in gameObject.PhysicsVertices)
-		{
-			writer.WriteStartObject();
-			writer.WriteNumber("x", vertex.X);
-			writer.WriteNumber("y", vertex.Y);
-			writer.WriteEndObject();
-		}
-	}
+    WriteString(writer, "parent_id", gameObject.ParentId?.Name);
 
-	writer.WriteEndArray();
+    WriteString(writer, "texture_mask_id", gameObject.TextureMaskId?.Name);
 
-	writer.WriteStartArray("events");
-	if (gameObject.Events != null)
-	{
-		foreach (IList<UndertaleGameObject.Event> eventList in gameObject.Events)
-		{
-			writer.WriteStartArray();
-			if (eventList != null)
-			{
-				foreach (UndertaleGameObject.Event objectEvent in eventList)
-				{
-					writer.WriteStartObject();
-					if (objectEvent != null)
-					{
-						writer.WriteNumber("event_subtype", objectEvent.EventSubtype);
-						writer.WriteStartArray("actions");
-						if (objectEvent.Actions != null)
-						{
-							foreach (UndertaleGameObject.EventAction action in objectEvent.Actions)
-							{
-								writer.WriteStartObject();
-								if (action != null)
-								{
-									writer.WriteNumber("lib_id", action.LibID);
-									writer.WriteNumber("id", action.ID);
-									writer.WriteNumber("kind", action.Kind);
-									writer.WriteBoolean("use_relative", action.UseRelative);
-									writer.WriteBoolean("is_question", action.IsQuestion);
-									writer.WriteBoolean("use_apply_to", action.UseApplyTo);
-									writer.WriteNumber("exe_type", action.ExeType);
+    writer.WriteBoolean("uses_physics", gameObject.UsesPhysics);
+    writer.WriteBoolean("is_sensor", gameObject.IsSensor);
+    writer.WriteNumber("collision_shape", Convert.ToInt32(gameObject.CollisionShape));
+    writer.WriteNumber("density", gameObject.Density);
+    writer.WriteNumber("restitution", gameObject.Restitution);
+    writer.WriteNumber("group", gameObject.Group);
+    writer.WriteNumber("linear_damping", gameObject.LinearDamping);
+    writer.WriteNumber("angular_damping", gameObject.AngularDamping);
+    writer.WriteNumber("friction", gameObject.Friction);
+    writer.WriteBoolean("awake", gameObject.Awake);
+    writer.WriteBoolean("kinematic", gameObject.Kinematic);
 
-									WriteString(writer, "action_name", action.ActionName);
+    writer.WriteStartArray("physics_vertices");
+    if (gameObject.PhysicsVertices != null)
+    {
+        foreach (UndertaleGameObject.UndertalePhysicsVertex vertex in gameObject.PhysicsVertices)
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("x", vertex.X);
+            writer.WriteNumber("y", vertex.Y);
+            writer.WriteEndObject();
+        }
+    }
 
-									WriteString(writer, "code_id", action.CodeId?.Name);
+    writer.WriteEndArray();
 
-									writer.WriteNumber("argument_count", action.ArgumentCount);
-									writer.WriteNumber("who", action.Who);
-									writer.WriteBoolean("relative", action.Relative);
-									writer.WriteBoolean("is_not", action.IsNot);
-								}
-								writer.WriteEndObject();
-							}
-						}
-						writer.WriteEndArray();
-					}
-					writer.WriteEndObject();
-				}
-			}
-			writer.WriteEndArray();
-		}
-	}
+    writer.WriteStartArray("events");
+    if (gameObject.Events != null)
+    {
+        foreach (IList<UndertaleGameObject.Event> eventList in gameObject.Events)
+        {
+            writer.WriteStartArray();
+            if (eventList != null)
+            {
+                foreach (UndertaleGameObject.Event objectEvent in eventList)
+                {
+                    writer.WriteStartObject();
+                    if (objectEvent != null)
+                    {
+                        writer.WriteNumber("event_subtype", objectEvent.EventSubtype);
+                        writer.WriteStartArray("actions");
+                        if (objectEvent.Actions != null)
+                        {
+                            foreach (UndertaleGameObject.EventAction action in objectEvent.Actions)
+                            {
+                                writer.WriteStartObject();
+                                if (action != null)
+                                {
+                                    writer.WriteNumber("lib_id", action.LibID);
+                                    writer.WriteNumber("id", action.ID);
+                                    writer.WriteNumber("kind", action.Kind);
+                                    writer.WriteBoolean("use_relative", action.UseRelative);
+                                    writer.WriteBoolean("is_question", action.IsQuestion);
+                                    writer.WriteBoolean("use_apply_to", action.UseApplyTo);
+                                    writer.WriteNumber("exe_type", action.ExeType);
 
-	writer.WriteEndArray();
+                                    WriteString(writer, "action_name", action.ActionName);
 
-	writer.WriteEndObject();
+                                    WriteString(writer, "code_id", action.CodeId?.Name);
 
-	writer.Flush();
+                                    writer.WriteNumber("argument_count", action.ArgumentCount);
+                                    writer.WriteNumber("who", action.Who);
+                                    writer.WriteBoolean("relative", action.Relative);
+                                    writer.WriteBoolean("is_not", action.IsNot);
+                                }
+                                writer.WriteEndObject();
+                            }
+                        }
+                        writer.WriteEndArray();
+                    }
+                    writer.WriteEndObject();
+                }
+            }
+            writer.WriteEndArray();
+        }
+    }
 
-	json = Encoding.UTF8.GetString(stream.ToArray());
-	return json;
+    writer.WriteEndArray();
+
+    writer.WriteEndObject();
+
+    writer.Flush();
+
+    File.WriteAllBytes(Path.Join(gameObjectOutputPath, gameObject.Name.Content) + ".json", stream.ToArray());
 }

--- a/UndertaleModTool/Unpackers/ExportAllRooms.csx
+++ b/UndertaleModTool/Unpackers/ExportAllRooms.csx
@@ -6,6 +6,8 @@ using System.Text;
 using System.Text.Json;
 using UndertaleModLib.Models;
 
+EnsureDataLoaded();
+
 ScriptMessage("Select the Room output directory");
 string roomOutputPath = PromptChooseDirectory("Export to where");
 if (roomOutputPath == null) throw new ScriptException("The room exporter's output path was not set.");

--- a/UndertaleModTool/Unpackers/ExportAllRooms.csx
+++ b/UndertaleModTool/Unpackers/ExportAllRooms.csx
@@ -270,8 +270,8 @@ void WriteRoomToJson(UndertaleRoom room)
                                         writer.WriteBoolean("sprite_mode", tile._SpriteMode);
                                         writer.WriteNumber("x", tile.X);
                                         writer.WriteNumber("y", tile.Y);
-                                        WriteString(writer, "background_definition", tile.SpriteDefinition?.Name);
-                                        WriteString(writer, "sprite_definition", tile.BackgroundDefinition?.Name);
+                                        WriteString(writer, "background_definition", tile.BackgroundDefinition?.Name);
+                                        WriteString(writer, "sprite_definition", tile.SpriteDefinition?.Name);
                                         writer.WriteNumber("source_x", tile.SourceX);
                                         writer.WriteNumber("source_y", tile.SourceY);
                                         writer.WriteNumber("width", tile.Width);
@@ -369,6 +369,8 @@ void WriteRoomToJson(UndertaleRoom room)
                         case UndertaleRoom.LayerType.Tiles:
                         {
                             UndertaleRoom.Layer.LayerTilesData layerData = (UndertaleRoom.Layer.LayerTilesData) layer.Data;
+
+                            WriteString(writer, "background", layerData.Background?.Name);
 
                             writer.WriteNumber("tiles_x", layerData.TilesX);
                             writer.WriteNumber("tiles_y", layerData.TilesY);

--- a/UndertaleModTool/Unpackers/ExportAllRooms.csx
+++ b/UndertaleModTool/Unpackers/ExportAllRooms.csx
@@ -49,7 +49,7 @@ void WriteRoomToJson(UndertaleRoom room)
     writer.WriteNumber("height", room.Height);
     writer.WriteNumber("speed", room.Speed);
     writer.WriteBoolean("persistent", room.Persistent);
-    writer.WriteNumber("background_color", room.BackgroundColor);
+    writer.WriteNumber("background_color", room.BackgroundColor ^ 0xFF000000); // remove alpha (BG color doesn't have alpha)
     writer.WriteBoolean("draw_background_color", room.DrawBackgroundColor);
 
     // GMS 2 Params

--- a/UndertaleModTool/Unpackers/ExportAllRooms.csx
+++ b/UndertaleModTool/Unpackers/ExportAllRooms.csx
@@ -10,406 +10,398 @@ ScriptMessage("Select the Room output directory");
 string roomOutputPath = PromptChooseDirectory("Export to where");
 if (roomOutputPath == null) throw new ScriptException("The room exporter's output path was not set.");
 
-StreamWriter sw;
+JsonWriterOptions writerOptions = new JsonWriterOptions { Indented = true };
 foreach (UndertaleRoom room in Data.Rooms)
 {
-	if (room != null)
-	{
-		try
-		{
-			string jsonString = RoomToJson(room);
-			sw = new StreamWriter(Path.Join(roomOutputPath, room.Name.Content) + ".json");
-			sw.Write(jsonString);
-		}
-		catch (Exception e)
-		{
-			throw e;
-		}
-		finally
-		{
-			if (sw != null) sw.Close();
-		}
-	}
+    if (room != null)
+    {
+        try
+        {
+            WriteRoomToJson(room);
+        }
+        catch (Exception e)
+        {
+            throw e;
+        }
+    }
 }
 
 void WriteString(Utf8JsonWriter writer, string propertyName, UndertaleString stringToWrite)
 {
-	if (stringToWrite?.Content == null)
-		writer.WriteNull(propertyName);
-	else
-		writer.WriteString(propertyName, stringToWrite.Content);
+    if (stringToWrite?.Content == null)
+        writer.WriteNull(propertyName);
+    else
+        writer.WriteString(propertyName, stringToWrite.Content);
 }
 
 
 // TODO: Use custom enum encoders
 
-string RoomToJson(UndertaleRoom room)
+void WriteRoomToJson(UndertaleRoom room)
 {
-	JsonWriterOptions writerOptions = new JsonWriterOptions {Indented = true};
-	using MemoryStream stream = new MemoryStream();
-	using Utf8JsonWriter writer = new Utf8JsonWriter(stream, writerOptions);
-	writer.WriteStartObject();
-	// Params
-	WriteString(writer, "name", room.Name);
-	WriteString(writer, "caption", room.Caption);
-	writer.WriteNumber("width", room.Width);
-	writer.WriteNumber("height", room.Height);
-	writer.WriteNumber("speed", room.Speed);
-	writer.WriteBoolean("persistent", room.Persistent);
-	writer.WriteNumber("background_color", room.BackgroundColor);
-	writer.WriteBoolean("draw_background_color", room.DrawBackgroundColor);
+    using MemoryStream stream = new MemoryStream();
+    using Utf8JsonWriter writer = new Utf8JsonWriter(stream, writerOptions);
+    writer.WriteStartObject();
+    // Params
+    WriteString(writer, "name", room.Name);
+    WriteString(writer, "caption", room.Caption);
+    writer.WriteNumber("width", room.Width);
+    writer.WriteNumber("height", room.Height);
+    writer.WriteNumber("speed", room.Speed);
+    writer.WriteBoolean("persistent", room.Persistent);
+    writer.WriteNumber("background_color", room.BackgroundColor);
+    writer.WriteBoolean("draw_background_color", room.DrawBackgroundColor);
 
-	// GMS 2 Params
-	WriteString(writer, "creation_code_id", room.CreationCodeId?.Name);
-	writer.WriteNumber("flags", Convert.ToInt32(room.Flags));
-	writer.WriteBoolean("world", room.World);
-	writer.WriteNumber("top", room.Top);
-	writer.WriteNumber("left", room.Left);
-	writer.WriteNumber("right", room.Right);
-	writer.WriteNumber("bottom", room.Bottom);
-	writer.WriteNumber("gravity_x", room.GravityX);
-	writer.WriteNumber("gravity_y", room.GravityY);
-	writer.WriteNumber("meters_per_pixel", room.MetersPerPixel);
+    // GMS 2 Params
+    WriteString(writer, "creation_code_id", room.CreationCodeId?.Name);
+    writer.WriteNumber("flags", Convert.ToInt32(room.Flags));
+    writer.WriteBoolean("world", room.World);
+    writer.WriteNumber("top", room.Top);
+    writer.WriteNumber("left", room.Left);
+    writer.WriteNumber("right", room.Right);
+    writer.WriteNumber("bottom", room.Bottom);
+    writer.WriteNumber("gravity_x", room.GravityX);
+    writer.WriteNumber("gravity_y", room.GravityY);
+    writer.WriteNumber("meters_per_pixel", room.MetersPerPixel);
 
-	// Now the part that sucks
+    // Now the part that sucks
 
-	// Backgrounds
-	writer.WriteStartArray("backgrounds");
-	if (room.Backgrounds != null)
-	{
-		foreach (UndertaleRoom.Background bg in room.Backgrounds)
-		{
-			writer.WriteStartObject();
-			if (bg != null)
-			{
-				writer.WriteNumber("calc_scale_x", bg.CalcScaleX);
-				writer.WriteNumber("calc_scale_y", bg.CalcScaleY);
-				writer.WriteBoolean("enabled", bg.Enabled);
-				writer.WriteBoolean("foreground", bg.Foreground);
-				WriteString(writer, "background_definition", bg.BackgroundDefinition?.Name);
-				writer.WriteNumber("x", bg.X);
-				writer.WriteNumber("y", bg.Y);
-				writer.WriteNumber("tile_x", bg.TileX);
-				writer.WriteNumber("tile_y", bg.TileY);
-				writer.WriteNumber("speed_x", bg.SpeedX);
-				writer.WriteNumber("speed_y", bg.SpeedY);
-				writer.WriteBoolean("stretch", bg.Stretch);
-			}
-			writer.WriteEndObject();
-		}
-	}
-	writer.WriteEndArray();
+    // Backgrounds
+    writer.WriteStartArray("backgrounds");
+    if (room.Backgrounds != null)
+    {
+        foreach (UndertaleRoom.Background bg in room.Backgrounds)
+        {
+            writer.WriteStartObject();
+            if (bg != null)
+            {
+                writer.WriteNumber("calc_scale_x", bg.CalcScaleX);
+                writer.WriteNumber("calc_scale_y", bg.CalcScaleY);
+                writer.WriteBoolean("enabled", bg.Enabled);
+                writer.WriteBoolean("foreground", bg.Foreground);
+                WriteString(writer, "background_definition", bg.BackgroundDefinition?.Name);
+                writer.WriteNumber("x", bg.X);
+                writer.WriteNumber("y", bg.Y);
+                writer.WriteNumber("tile_x", bg.TileX);
+                writer.WriteNumber("tile_y", bg.TileY);
+                writer.WriteNumber("speed_x", bg.SpeedX);
+                writer.WriteNumber("speed_y", bg.SpeedY);
+                writer.WriteBoolean("stretch", bg.Stretch);
+            }
+            writer.WriteEndObject();
+        }
+    }
+    writer.WriteEndArray();
 
-	// Views
-	writer.WriteStartArray("views");
-	if (room.Views != null)
-	{
-		foreach (UndertaleRoom.View view in room.Views)
-		{
-			writer.WriteStartObject();
-			if (view != null)
-			{
-				writer.WriteBoolean("enabled", view.Enabled);
-				writer.WriteNumber("view_x", view.ViewX);
-				writer.WriteNumber("view_y", view.ViewY);
-				writer.WriteNumber("view_width", view.ViewWidth);
-				writer.WriteNumber("view_height", view.ViewHeight);
-				writer.WriteNumber("port_x", view.PortX);
-				writer.WriteNumber("port_y", view.PortY);
-				writer.WriteNumber("port_width", view.PortWidth);
-				writer.WriteNumber("port_height", view.PortHeight);
-				writer.WriteNumber("border_x", view.BorderX);
-				writer.WriteNumber("border_y", view.BorderY);
-				writer.WriteNumber("speed_x", view.SpeedX);
-				writer.WriteNumber("speed_y", view.SpeedY);
-				WriteString(writer, "object_id", view.ObjectId?.Name);
-			}
-			writer.WriteEndObject();
-		}
-	}
-	writer.WriteEndArray();
+    // Views
+    writer.WriteStartArray("views");
+    if (room.Views != null)
+    {
+        foreach (UndertaleRoom.View view in room.Views)
+        {
+            writer.WriteStartObject();
+            if (view != null)
+            {
+                writer.WriteBoolean("enabled", view.Enabled);
+                writer.WriteNumber("view_x", view.ViewX);
+                writer.WriteNumber("view_y", view.ViewY);
+                writer.WriteNumber("view_width", view.ViewWidth);
+                writer.WriteNumber("view_height", view.ViewHeight);
+                writer.WriteNumber("port_x", view.PortX);
+                writer.WriteNumber("port_y", view.PortY);
+                writer.WriteNumber("port_width", view.PortWidth);
+                writer.WriteNumber("port_height", view.PortHeight);
+                writer.WriteNumber("border_x", view.BorderX);
+                writer.WriteNumber("border_y", view.BorderY);
+                writer.WriteNumber("speed_x", view.SpeedX);
+                writer.WriteNumber("speed_y", view.SpeedY);
+                WriteString(writer, "object_id", view.ObjectId?.Name);
+            }
+            writer.WriteEndObject();
+        }
+    }
+    writer.WriteEndArray();
 
-	// GameObjects
-	writer.WriteStartArray("game_objects");
-	if (room.GameObjects != null)
-	{
-		foreach (UndertaleRoom.GameObject go in room.GameObjects)
-		{
-			writer.WriteStartObject();
-			if (go != null)
-			{
-				writer.WriteNumber("x", go.X);
-				writer.WriteNumber("y", go.Y);
-				WriteString(writer, "object_definition", go.ObjectDefinition?.Name);
-				writer.WriteNumber("instance_id", go.InstanceID);
-				WriteString(writer, "creation_code", go.CreationCode?.Name);
-				writer.WriteNumber("scale_x", go.ScaleX);
-				writer.WriteNumber("scale_y", go.ScaleY);
-				writer.WriteNumber("color", go.Color);
-				writer.WriteNumber("rotation", go.Rotation);
-				WriteString(writer, "pre_create_code", go.PreCreateCode?.Name);
-				writer.WriteNumber("image_speed", go.ImageSpeed);
-				writer.WriteNumber("image_index", go.ImageIndex);
-			}
-			writer.WriteEndObject();
-		}
-	}
-	writer.WriteEndArray();
+    // GameObjects
+    writer.WriteStartArray("game_objects");
+    if (room.GameObjects != null)
+    {
+        foreach (UndertaleRoom.GameObject go in room.GameObjects)
+        {
+            writer.WriteStartObject();
+            if (go != null)
+            {
+                writer.WriteNumber("x", go.X);
+                writer.WriteNumber("y", go.Y);
+                WriteString(writer, "object_definition", go.ObjectDefinition?.Name);
+                writer.WriteNumber("instance_id", go.InstanceID);
+                WriteString(writer, "creation_code", go.CreationCode?.Name);
+                writer.WriteNumber("scale_x", go.ScaleX);
+                writer.WriteNumber("scale_y", go.ScaleY);
+                writer.WriteNumber("color", go.Color);
+                writer.WriteNumber("rotation", go.Rotation);
+                WriteString(writer, "pre_create_code", go.PreCreateCode?.Name);
+                writer.WriteNumber("image_speed", go.ImageSpeed);
+                writer.WriteNumber("image_index", go.ImageIndex);
+            }
+            writer.WriteEndObject();
+        }
+    }
+    writer.WriteEndArray();
 
-	// Tiles
-	writer.WriteStartArray("tiles");
-	if (room.Tiles != null)
-	{
-		foreach (UndertaleRoom.Tile tile in room.Tiles)
-		{
-			writer.WriteStartObject();
-			if (tile != null)
-			{
-				writer.WriteBoolean("sprite_mode", tile._SpriteMode);
-				writer.WriteNumber("x", tile.X);
-				writer.WriteNumber("y", tile.Y);
-				WriteString(writer, "background_definition", tile.BackgroundDefinition?.Name);
-				WriteString(writer, "sprite_definition", tile.SpriteDefinition?.Name);
-				writer.WriteNumber("source_x", tile.SourceX);
-				writer.WriteNumber("source_y", tile.SourceY);
-				writer.WriteNumber("width", tile.Width);
-				writer.WriteNumber("height", tile.Height);
-				writer.WriteNumber("tile_depth", tile.TileDepth);
-				writer.WriteNumber("instance_id", tile.InstanceID);
-				writer.WriteNumber("scale_x", tile.ScaleX);
-				writer.WriteNumber("scale_y", tile.ScaleY);
-				writer.WriteNumber("color", tile.Color);
-			}
-			writer.WriteEndObject();
-		}
-	}
-	writer.WriteEndArray();
+    // Tiles
+    writer.WriteStartArray("tiles");
+    if (room.Tiles != null)
+    {
+        foreach (UndertaleRoom.Tile tile in room.Tiles)
+        {
+            writer.WriteStartObject();
+            if (tile != null)
+            {
+                writer.WriteBoolean("sprite_mode", tile._SpriteMode);
+                writer.WriteNumber("x", tile.X);
+                writer.WriteNumber("y", tile.Y);
+                WriteString(writer, "background_definition", tile.BackgroundDefinition?.Name);
+                WriteString(writer, "sprite_definition", tile.SpriteDefinition?.Name);
+                writer.WriteNumber("source_x", tile.SourceX);
+                writer.WriteNumber("source_y", tile.SourceY);
+                writer.WriteNumber("width", tile.Width);
+                writer.WriteNumber("height", tile.Height);
+                writer.WriteNumber("tile_depth", tile.TileDepth);
+                writer.WriteNumber("instance_id", tile.InstanceID);
+                writer.WriteNumber("scale_x", tile.ScaleX);
+                writer.WriteNumber("scale_y", tile.ScaleY);
+                writer.WriteNumber("color", tile.Color);
+            }
+            writer.WriteEndObject();
+        }
+    }
+    writer.WriteEndArray();
 
-	// Layers
-	// This is the part that super sucks
+    // Layers
+    // This is the part that super sucks
 
-	writer.WriteStartArray("layers");
-	if (room.Layers != null)
-	{
-		foreach (UndertaleRoom.Layer layer in room.Layers)
-		{
-			writer.WriteStartObject();
-			if (layer != null)
-			{
-				//layer params
-				WriteString(writer, "layer_name", layer.LayerName);
-				writer.WriteNumber("layer_id", layer.LayerId);
-				writer.WriteNumber("layer_type", Convert.ToInt32(layer.LayerType));
-				writer.WriteNumber("layer_depth", layer.LayerDepth);
-				writer.WriteNumber("x_offset", layer.XOffset);
-				writer.WriteNumber("y_offset", layer.YOffset);
-				writer.WriteNumber("h_speed", layer.HSpeed);
-				writer.WriteNumber("v_speed", layer.VSpeed);
-				writer.WriteBoolean("is_visible", layer.IsVisible);
+    writer.WriteStartArray("layers");
+    if (room.Layers != null)
+    {
+        foreach (UndertaleRoom.Layer layer in room.Layers)
+        {
+            writer.WriteStartObject();
+            if (layer != null)
+            {
+                //layer params
+                WriteString(writer, "layer_name", layer.LayerName);
+                writer.WriteNumber("layer_id", layer.LayerId);
+                writer.WriteNumber("layer_type", Convert.ToInt32(layer.LayerType));
+                writer.WriteNumber("layer_depth", layer.LayerDepth);
+                writer.WriteNumber("x_offset", layer.XOffset);
+                writer.WriteNumber("y_offset", layer.YOffset);
+                writer.WriteNumber("h_speed", layer.HSpeed);
+                writer.WriteNumber("v_speed", layer.VSpeed);
+                writer.WriteBoolean("is_visible", layer.IsVisible);
 
-				writer.WriteStartObject("layer_data");
-				if (layer.Data != null)
-				{
-					switch (layer.LayerType)
-					{
-						case UndertaleRoom.LayerType.Background:
-						{
-							UndertaleRoom.Layer.LayerBackgroundData layerData = (UndertaleRoom.Layer.LayerBackgroundData) layer.Data;
+                writer.WriteStartObject("layer_data");
+                if (layer.Data != null)
+                {
+                    switch (layer.LayerType)
+                    {
+                        case UndertaleRoom.LayerType.Background:
+                        {
+                            UndertaleRoom.Layer.LayerBackgroundData layerData = (UndertaleRoom.Layer.LayerBackgroundData) layer.Data;
 
-							writer.WriteNumber("calc_scale_x", layerData.CalcScaleX);
-							writer.WriteNumber("calc_scale_y", layerData.CalcScaleY);
-							writer.WriteBoolean("visible", layerData.Visible);
-							writer.WriteBoolean("foreground", layerData.Foreground);
-							WriteString(writer, "sprite", layerData.Sprite?.Name);
-							writer.WriteBoolean("tiled_horizontally", layerData.TiledHorizontally);
-							writer.WriteBoolean("tiled_vertically", layerData.TiledVertically);
-							writer.WriteBoolean("stretch", layerData.Stretch);
-							writer.WriteNumber("color", layerData.Color);
-							writer.WriteNumber("first_frame", layerData.FirstFrame);
-							writer.WriteNumber("animation_speed", layerData.AnimationSpeed);
-							writer.WriteNumber("animation_speed_type", Convert.ToInt32(layerData.AnimationSpeedType));
-							break;
-						}
-						case UndertaleRoom.LayerType.Instances:
-						{
-							UndertaleRoom.Layer.LayerInstancesData layerData = (UndertaleRoom.Layer.LayerInstancesData) layer.Data;
+                            writer.WriteNumber("calc_scale_x", layerData.CalcScaleX);
+                            writer.WriteNumber("calc_scale_y", layerData.CalcScaleY);
+                            writer.WriteBoolean("visible", layerData.Visible);
+                            writer.WriteBoolean("foreground", layerData.Foreground);
+                            WriteString(writer, "sprite", layerData.Sprite?.Name);
+                            writer.WriteBoolean("tiled_horizontally", layerData.TiledHorizontally);
+                            writer.WriteBoolean("tiled_vertically", layerData.TiledVertically);
+                            writer.WriteBoolean("stretch", layerData.Stretch);
+                            writer.WriteNumber("color", layerData.Color);
+                            writer.WriteNumber("first_frame", layerData.FirstFrame);
+                            writer.WriteNumber("animation_speed", layerData.AnimationSpeed);
+                            writer.WriteNumber("animation_speed_type", Convert.ToInt32(layerData.AnimationSpeedType));
+                            break;
+                        }
+                        case UndertaleRoom.LayerType.Instances:
+                        {
+                            UndertaleRoom.Layer.LayerInstancesData layerData = (UndertaleRoom.Layer.LayerInstancesData) layer.Data;
 
-							writer.WriteStartArray("instances");
-							if (layerData.Instances != null)
-							{
-								foreach (UndertaleRoom.GameObject instance in layerData.Instances)
-								{
-									writer.WriteStartObject();
-									if (instance != null)
-									{
-										writer.WriteNumber("x", instance.X);
-										writer.WriteNumber("y", instance.Y);
-										WriteString(writer, "object_definition", instance.ObjectDefinition?.Name);
-										writer.WriteNumber("instance_id", instance.InstanceID);
-										WriteString(writer, "creation_code", instance.CreationCode?.Name);
-										writer.WriteNumber("scale_x", instance.ScaleX);
-										writer.WriteNumber("scale_y", instance.ScaleY);
-										writer.WriteNumber("color", instance.Color);
-										writer.WriteNumber("rotation", instance.Rotation);
-										WriteString(writer, "pre_create_code", instance.PreCreateCode?.Name);
-										writer.WriteNumber("image_speed", instance.ImageSpeed);
-										writer.WriteNumber("image_index", instance.ImageIndex);
-									}
-									writer.WriteEndObject();
-								}
-							}
-							writer.WriteEndArray();
-							break;
-						}
-						// Awful^3
-						case UndertaleRoom.LayerType.Assets:
-						{
-							UndertaleRoom.Layer.LayerAssetsData layerData = (UndertaleRoom.Layer.LayerAssetsData) layer.Data;
-							// Tiles
-							writer.WriteStartArray("legacy_tiles");
-							if (layerData.LegacyTiles != null)
-							{
-								foreach (UndertaleRoom.Tile tile in layerData.LegacyTiles)
-								{
-									writer.WriteStartObject();
-									if (tile != null)
-									{
-										writer.WriteBoolean("sprite_mode", tile._SpriteMode);
-										writer.WriteNumber("x", tile.X);
-										writer.WriteNumber("y", tile.Y);
-										WriteString(writer, "background_definition", tile.SpriteDefinition?.Name);
-										WriteString(writer, "sprite_definition", tile.BackgroundDefinition?.Name);
-										writer.WriteNumber("source_x", tile.SourceX);
-										writer.WriteNumber("source_y", tile.SourceY);
-										writer.WriteNumber("width", tile.Width);
-										writer.WriteNumber("height", tile.Height);
-										writer.WriteNumber("tile_depth", tile.TileDepth);
-										writer.WriteNumber("instance_id", tile.InstanceID);
-										writer.WriteNumber("scale_x", tile.ScaleX);
-										writer.WriteNumber("scale_y", tile.ScaleY);
-										writer.WriteNumber("color", tile.Color);
-									}
-									writer.WriteEndObject();
-								}
-							}
-							writer.WriteEndArray();
+                            writer.WriteStartArray("instances");
+                            if (layerData.Instances != null)
+                            {
+                                foreach (UndertaleRoom.GameObject instance in layerData.Instances)
+                                {
+                                    writer.WriteStartObject();
+                                    if (instance != null)
+                                    {
+                                        writer.WriteNumber("x", instance.X);
+                                        writer.WriteNumber("y", instance.Y);
+                                        WriteString(writer, "object_definition", instance.ObjectDefinition?.Name);
+                                        writer.WriteNumber("instance_id", instance.InstanceID);
+                                        WriteString(writer, "creation_code", instance.CreationCode?.Name);
+                                        writer.WriteNumber("scale_x", instance.ScaleX);
+                                        writer.WriteNumber("scale_y", instance.ScaleY);
+                                        writer.WriteNumber("color", instance.Color);
+                                        writer.WriteNumber("rotation", instance.Rotation);
+                                        WriteString(writer, "pre_create_code", instance.PreCreateCode?.Name);
+                                        writer.WriteNumber("image_speed", instance.ImageSpeed);
+                                        writer.WriteNumber("image_index", instance.ImageIndex);
+                                    }
+                                    writer.WriteEndObject();
+                                }
+                            }
+                            writer.WriteEndArray();
+                            break;
+                        }
+                        // Awful^3
+                        case UndertaleRoom.LayerType.Assets:
+                        {
+                            UndertaleRoom.Layer.LayerAssetsData layerData = (UndertaleRoom.Layer.LayerAssetsData) layer.Data;
+                            // Tiles
+                            writer.WriteStartArray("legacy_tiles");
+                            if (layerData.LegacyTiles != null)
+                            {
+                                foreach (UndertaleRoom.Tile tile in layerData.LegacyTiles)
+                                {
+                                    writer.WriteStartObject();
+                                    if (tile != null)
+                                    {
+                                        writer.WriteBoolean("sprite_mode", tile._SpriteMode);
+                                        writer.WriteNumber("x", tile.X);
+                                        writer.WriteNumber("y", tile.Y);
+                                        WriteString(writer, "background_definition", tile.SpriteDefinition?.Name);
+                                        WriteString(writer, "sprite_definition", tile.BackgroundDefinition?.Name);
+                                        writer.WriteNumber("source_x", tile.SourceX);
+                                        writer.WriteNumber("source_y", tile.SourceY);
+                                        writer.WriteNumber("width", tile.Width);
+                                        writer.WriteNumber("height", tile.Height);
+                                        writer.WriteNumber("tile_depth", tile.TileDepth);
+                                        writer.WriteNumber("instance_id", tile.InstanceID);
+                                        writer.WriteNumber("scale_x", tile.ScaleX);
+                                        writer.WriteNumber("scale_y", tile.ScaleY);
+                                        writer.WriteNumber("color", tile.Color);
+                                    }
+                                    writer.WriteEndObject();
+                                }
+                            }
+                            writer.WriteEndArray();
 
-							// Sprites
-							writer.WriteStartArray("sprites");
-							if (layerData.Sprites != null)
-							{
-								foreach (UndertaleRoom.SpriteInstance sprite in layerData.Sprites)
-								{
-									writer.WriteStartObject();
-									if (sprite != null)
-									{
-										WriteString(writer, "name", sprite.Name);
-										WriteString(writer, "sprite", sprite.Sprite?.Name);
-										writer.WriteNumber("x", sprite.X);
-										writer.WriteNumber("y", sprite.Y);
-										writer.WriteNumber("scale_x", sprite.ScaleX);
-										writer.WriteNumber("scale_y", sprite.ScaleY);
-										writer.WriteNumber("color", sprite.Color);
-										writer.WriteNumber("animation_speed", sprite.AnimationSpeed);
-										writer.WriteNumber("animation_speed_type", Convert.ToInt32(sprite.AnimationSpeedType));
-										writer.WriteNumber("frame_index", sprite.FrameIndex);
-										writer.WriteNumber("rotation", sprite.Rotation);
-									}
-									writer.WriteEndObject();
-								}
-							}
-							writer.WriteEndArray();
+                            // Sprites
+                            writer.WriteStartArray("sprites");
+                            if (layerData.Sprites != null)
+                            {
+                                foreach (UndertaleRoom.SpriteInstance sprite in layerData.Sprites)
+                                {
+                                    writer.WriteStartObject();
+                                    if (sprite != null)
+                                    {
+                                        WriteString(writer, "name", sprite.Name);
+                                        WriteString(writer, "sprite", sprite.Sprite?.Name);
+                                        writer.WriteNumber("x", sprite.X);
+                                        writer.WriteNumber("y", sprite.Y);
+                                        writer.WriteNumber("scale_x", sprite.ScaleX);
+                                        writer.WriteNumber("scale_y", sprite.ScaleY);
+                                        writer.WriteNumber("color", sprite.Color);
+                                        writer.WriteNumber("animation_speed", sprite.AnimationSpeed);
+                                        writer.WriteNumber("animation_speed_type", Convert.ToInt32(sprite.AnimationSpeedType));
+                                        writer.WriteNumber("frame_index", sprite.FrameIndex);
+                                        writer.WriteNumber("rotation", sprite.Rotation);
+                                    }
+                                    writer.WriteEndObject();
+                                }
+                            }
+                            writer.WriteEndArray();
 
-							// Sequences
-							writer.WriteStartArray("sequences");
-							if (layerData.Sequences != null)
-							{
-								foreach (UndertaleRoom.SequenceInstance sequence in layerData.Sequences)
-								{
-									writer.WriteStartObject();
-									if (sequence != null)
-									{
-										WriteString(writer, "name", sequence.Name);
-										WriteString(writer, "sequence", sequence.Sequence?.Name);
-										writer.WriteNumber("x", sequence.X);
-										writer.WriteNumber("y", sequence.Y);
-										writer.WriteNumber("scale_x", sequence.ScaleX);
-										writer.WriteNumber("scale_y", sequence.ScaleY);
-										writer.WriteNumber("color", sequence.Color);
-										writer.WriteNumber("animation_speed", sequence.AnimationSpeed);
-										writer.WriteNumber("animation_speed_type", Convert.ToInt32(sequence.AnimationSpeedType));
-										writer.WriteNumber("frame_index", sequence.FrameIndex);
-										writer.WriteNumber("rotation", sequence.Rotation);
-									}
-									writer.WriteEndObject();
-								}
-							}
-							writer.WriteEndArray();
+                            // Sequences
+                            writer.WriteStartArray("sequences");
+                            if (layerData.Sequences != null)
+                            {
+                                foreach (UndertaleRoom.SequenceInstance sequence in layerData.Sequences)
+                                {
+                                    writer.WriteStartObject();
+                                    if (sequence != null)
+                                    {
+                                        WriteString(writer, "name", sequence.Name);
+                                        WriteString(writer, "sequence", sequence.Sequence?.Name);
+                                        writer.WriteNumber("x", sequence.X);
+                                        writer.WriteNumber("y", sequence.Y);
+                                        writer.WriteNumber("scale_x", sequence.ScaleX);
+                                        writer.WriteNumber("scale_y", sequence.ScaleY);
+                                        writer.WriteNumber("color", sequence.Color);
+                                        writer.WriteNumber("animation_speed", sequence.AnimationSpeed);
+                                        writer.WriteNumber("animation_speed_type", Convert.ToInt32(sequence.AnimationSpeedType));
+                                        writer.WriteNumber("frame_index", sequence.FrameIndex);
+                                        writer.WriteNumber("rotation", sequence.Rotation);
+                                    }
+                                    writer.WriteEndObject();
+                                }
+                            }
+                            writer.WriteEndArray();
 
-							// NineSlices
-							writer.WriteStartArray("nine_slices");
-							if (layerData.NineSlices != null)
-							{
-								foreach (UndertaleRoom.SpriteInstance nineSlice in layerData.NineSlices)
-								{
-									writer.WriteStartObject();
-									if (nineSlice != null)
-									{
-										WriteString(writer, "name", nineSlice.Name);
-										WriteString(writer, "sprite", nineSlice.Sprite?.Name);
-										writer.WriteNumber("x", nineSlice.X);
-										writer.WriteNumber("y", nineSlice.Y);
-										writer.WriteNumber("scale_x", nineSlice.ScaleX);
-										writer.WriteNumber("scale_y", nineSlice.ScaleY);
-										writer.WriteNumber("color", nineSlice.Color);
-										writer.WriteNumber("animation_speed", nineSlice.AnimationSpeed);
-										writer.WriteNumber("animation_speed_type", Convert.ToInt32(nineSlice.AnimationSpeedType));
-										writer.WriteNumber("frame_index", nineSlice.FrameIndex);
-										writer.WriteNumber("rotation", nineSlice.Rotation);
-									}
-									writer.WriteEndObject();
-								}
-							}
-							writer.WriteEndArray();
-							break;
-						}
-						case UndertaleRoom.LayerType.Tiles:
-						{
-							UndertaleRoom.Layer.LayerTilesData layerData = (UndertaleRoom.Layer.LayerTilesData) layer.Data;
+                            // NineSlices
+                            writer.WriteStartArray("nine_slices");
+                            if (layerData.NineSlices != null)
+                            {
+                                foreach (UndertaleRoom.SpriteInstance nineSlice in layerData.NineSlices)
+                                {
+                                    writer.WriteStartObject();
+                                    if (nineSlice != null)
+                                    {
+                                        WriteString(writer, "name", nineSlice.Name);
+                                        WriteString(writer, "sprite", nineSlice.Sprite?.Name);
+                                        writer.WriteNumber("x", nineSlice.X);
+                                        writer.WriteNumber("y", nineSlice.Y);
+                                        writer.WriteNumber("scale_x", nineSlice.ScaleX);
+                                        writer.WriteNumber("scale_y", nineSlice.ScaleY);
+                                        writer.WriteNumber("color", nineSlice.Color);
+                                        writer.WriteNumber("animation_speed", nineSlice.AnimationSpeed);
+                                        writer.WriteNumber("animation_speed_type", Convert.ToInt32(nineSlice.AnimationSpeedType));
+                                        writer.WriteNumber("frame_index", nineSlice.FrameIndex);
+                                        writer.WriteNumber("rotation", nineSlice.Rotation);
+                                    }
+                                    writer.WriteEndObject();
+                                }
+                            }
+                            writer.WriteEndArray();
+                            break;
+                        }
+                        case UndertaleRoom.LayerType.Tiles:
+                        {
+                            UndertaleRoom.Layer.LayerTilesData layerData = (UndertaleRoom.Layer.LayerTilesData) layer.Data;
 
-							writer.WriteNumber("tiles_x", layerData.TilesX);
-							writer.WriteNumber("tiles_y", layerData.TilesY);
+                            writer.WriteNumber("tiles_x", layerData.TilesX);
+                            writer.WriteNumber("tiles_y", layerData.TilesY);
 
-							writer.WriteStartArray("tile_data");
-							if (layerData.TileData != null)
-							{
-								foreach (uint[] tile in layerData.TileData)
-								{
-									writer.WriteStartArray();
-									foreach (uint tileId in tile)
-									{
-										writer.WriteStartObject();
-										writer.WriteNumber("id", tileId);
-										writer.WriteEndObject();
-									}
-									writer.WriteEndArray();
-								}
-							}
-							writer.WriteEndArray();
-							break;
-						}
-					}
-				}
-				writer.WriteEndObject();
-			}
-			writer.WriteEndObject();
-		}
-	}
-	writer.WriteEndArray();
+                            writer.WriteStartArray("tile_data");
+                            if (layerData.TileData != null)
+                            {
+                                foreach (uint[] tile in layerData.TileData)
+                                {
+                                    writer.WriteStartArray();
+                                    foreach (uint tileId in tile)
+                                    {
+                                        writer.WriteStartObject();
+                                        writer.WriteNumber("id", tileId);
+                                        writer.WriteEndObject();
+                                    }
+                                    writer.WriteEndArray();
+                                }
+                            }
+                            writer.WriteEndArray();
+                            break;
+                        }
+                    }
+                }
+                writer.WriteEndObject();
+            }
+            writer.WriteEndObject();
+        }
+    }
+    writer.WriteEndArray();
 
-	writer.WriteEndObject();
-	writer.Flush();
+    writer.WriteEndObject();
+    writer.Flush();
 
-	string json = Encoding.UTF8.GetString(stream.ToArray());
-	return json;
+    File.WriteAllBytes(Path.Join(roomOutputPath, room.Name.Content) + ".json", stream.ToArray());
 }


### PR DESCRIPTION
1. Reduced memory usage of export scripts by bypassing `byte[]` to `string` conversion.
2. Converted tabs to spaces _(as in other UTMT code)_.
3. Fixed assets (legacy tiles) and tiles room layers export and import.
4. Fixed error on layer background sprite _(`BackgroundData.Sprite`)_ modifying.
5. Background color of room is not saved _(as in `Serialize()`/`Unserialize()` of `UndertaleRoom`)_.